### PR TITLE
Add article to quiz

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,5 @@ db/postgres-data
 # vscode files
 
 .vscode/*
+
+data/articles

--- a/cmd/db_populator/main.go
+++ b/cmd/db_populator/main.go
@@ -59,8 +59,8 @@ func createSampleQuizArticle(db *sql.DB, quizID uuid.UUID) {
 		},
 		ImgURL: url.URL{
 			Scheme: "https",
-			Host:   "www.unsplash.it",
-			Path:   "/200/200",
+			Host:   "www.picsum.photos",
+			Path:   "/id/1062/500/300",
 		},
 	}
 
@@ -89,7 +89,7 @@ func createSampleQuiz(db *sql.DB, title string) {
 		`INSERT INTO quizzes (title, available_from, available_to, image_url)
 		values ($1, $2, $3, $4)
 		RETURNING id;`,
-		title, time.Now(), time.Now().Add(time.Hour*24*7), "https://www.unsplash.it/200/200")
+		title, time.Now(), time.Now().Add(time.Hour*24*7), "https://picsum.photos/id/1062/500/300")
 
 	err := row.Scan(&quiz_id)
 	if err != nil {
@@ -126,7 +126,7 @@ func createQuestion(db *sql.DB, quiz_id uuid.UUID, question question) {
 	tx.Exec(
 		`INSERT INTO questions (id, question, image_url, article_id, quiz_id, points)
 		VALUES ($1, $2, $3, $4, $5, $6);`,
-		question_id, question.text, "https://unsplash.it/200/200", nil, quiz_id, 10)
+		question_id, question.text, "https://picsum.photos/id/1062/500/300", nil, quiz_id, 10)
 
 	for _, a := range question.answer_alts {
 		alternative_id := uuid.New()

--- a/db/migrations/000001_init.up.sql
+++ b/db/migrations/000001_init.up.sql
@@ -18,7 +18,7 @@ CREATE TABLE IF NOT EXISTS users (
 CREATE TABLE IF NOT EXISTS articles (
     id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
     title TEXT NOT NULL,
-    url TEXT NOT NULL,
+    url TEXT NOT NULL UNIQUE,
     image_url TEXT
 );
 

--- a/internal/models/articles/articles.go
+++ b/internal/models/articles/articles.go
@@ -194,23 +194,6 @@ func AddArticleToQuiz(db *sql.DB, articleID *uuid.UUID, quizID *uuid.UUID) error
 	return err
 }
 
-// Get an Article's data by its URL.
-func GetArticleDataByURL(articleURL url.URL) (Article, error) {
-	tempID := uuid.NullUUID{
-		UUID:  uuid.New(),
-		Valid: true,
-	}
-
-	article := Article{
-		ID:         tempID,
-		Title:      "Test article",
-		ArticleURL: articleURL,
-		ImgURL:     url.URL{},
-	}
-
-	return article, nil
-}
-
 func IsArticleInQuiz(db *sql.DB, articleID *uuid.UUID, quizID *uuid.UUID) (bool, error) {
 	row := db.QueryRow(
 		`SELECT

--- a/internal/models/articles/articles.go
+++ b/internal/models/articles/articles.go
@@ -194,6 +194,8 @@ func AddArticleToQuiz(db *sql.DB, articleID *uuid.UUID, quizID *uuid.UUID) error
 	return err
 }
 
+// Returns 'true' if it finds the article in the quiz in the DB.
+// Returns 'false' if it does not find it.
 func IsArticleInQuiz(db *sql.DB, articleID *uuid.UUID, quizID *uuid.UUID) (bool, error) {
 	row := db.QueryRow(
 		`SELECT

--- a/internal/models/articles/articles.go
+++ b/internal/models/articles/articles.go
@@ -245,8 +245,8 @@ var SampleArticles []Article = []Article{
 		},
 		ImgURL: url.URL{
 			Scheme: "https",
-			Host:   "unsplash.it",
-			Path:   "/200/200",
+			Host:   "www.picsum.photos",
+			Path:   "/id/1062/500/300",
 		},
 	},
 	{
@@ -262,8 +262,8 @@ var SampleArticles []Article = []Article{
 		},
 		ImgURL: url.URL{
 			Scheme: "https",
-			Host:   "unsplash.it",
-			Path:   "/200/200",
+			Host:   "www.picsum.photos",
+			Path:   "/id/1062/500/300",
 		},
 	},
 }

--- a/internal/models/articles/third_party_articles.go
+++ b/internal/models/articles/third_party_articles.go
@@ -1,0 +1,45 @@
+package articles
+
+// The data structure for a third party article (Sunnmørsposten).
+type ArticleSMP struct {
+	SchemaVersion int    `json:"schemaVersion"`
+	SchemaType    string `json:"schemaType"`
+	ID            string `json:"id"`
+	Section       struct {
+		ID      string `json:"id"`
+		Title   string `json:"title"`
+		Enabled bool   `json:"enabled"`
+	} `json:"section"`
+	Title struct {
+		Value string `json:"value"`
+	} `json:"title"`
+	Components []struct {
+		Caption struct {
+			Value string `json:"value"`
+		} `json:"caption,omitempty"`
+		Byline struct {
+			Title string `json:"title"`
+		} `json:"byline,omitempty"`
+		ImageAsset struct {
+			ID   string `json:"id"`
+			Size struct {
+				Width  int `json:"width"`
+				Height int `json:"height"`
+			} `json:"size"`
+		} `json:"imageAsset,omitempty"`
+		Characteristics struct {
+			Figure    bool `json:"figure"`
+			Sensitive bool `json:"sensitive"`
+		} `json:"characteristics,omitempty"`
+		Type       string `json:"type"`
+		Paragraphs []struct {
+			Text struct {
+				Value string `json:"value"`
+			} `json:"text"`
+			BlockType string `json:"blockType"`
+		} `json:"paragraphs,omitempty"`
+		Subtype string `json:"subtype,omitempty"`
+	} `json:"components"`
+}
+
+// Some sample articles for testing purposes.

--- a/internal/models/articles/third_party_articles.go
+++ b/internal/models/articles/third_party_articles.go
@@ -1,5 +1,17 @@
 package articles
 
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"log"
+	"net/url"
+	"os"
+	"strings"
+
+	"github.com/google/uuid"
+)
+
 // The data structure for a third party article (Sunnmørsposten).
 type ArticleSMP struct {
 	SchemaVersion int    `json:"schemaVersion"`
@@ -43,3 +55,97 @@ type ArticleSMP struct {
 }
 
 // Some sample articles for testing purposes.
+func readJSONtoArticleSMP(filename string) (ArticleSMP, error) {
+	// Open file
+	file, err := os.Open(filename)
+
+	if err != nil {
+		log.Println("Error opening file: ", err)
+		return ArticleSMP{}, err
+	}
+	defer file.Close()
+
+	// Read file
+	byteValue, err := io.ReadAll(file)
+
+	var article ArticleSMP
+	err = json.Unmarshal(byteValue, &article)
+	if err != nil {
+		log.Println("Error parsing JSON: ", err)
+		return ArticleSMP{}, err
+	}
+
+	return article, nil
+}
+
+// Get the ID for ArticleSMP from the article URL.
+func getSmpIdFromString(url string) (string, error) {
+	// Split the URL by "/"
+	parts := strings.Split(url, "/")
+
+	var index int
+	for i, part := range parts {
+		if part == "i" {
+			index = i
+			break
+		}
+	}
+
+	// Get the article ID
+	if index+1 < len(parts) {
+		return parts[index+1], nil
+	}
+
+	return "", nil
+}
+
+// Get the main image of the article (the first image).
+func getMainImageOfArticle(article ArticleSMP) (*url.URL, error) {
+	for _, component := range article.Components {
+		if component.Type == "image" {
+			return url.Parse(fmt.Sprintf("https://vcdn.polarismedia.no/%s?fit=clip&h=700&q=80&tight=false&w=1000", component.ImageAsset.ID))
+		}
+	}
+
+	return &url.URL{}, nil
+}
+
+func GetArticleByURL(articleUrl string) (Article, error) {
+	// TODO: Update this to fetch the article from the web instead of reading it from JSON.
+
+	// Get article's SMP ID
+	articleID, err := getSmpIdFromString(articleUrl)
+	if err != nil {
+		return Article{}, err
+	}
+
+	// Get the article data from the JSON file
+	articleSMP, err := readJSONtoArticleSMP(fmt.Sprintf("data/articles/%s.json", articleID))
+	if err != nil {
+		return Article{}, err
+	}
+
+	// Parse the article URL
+	tempURL, err := url.Parse(articleUrl)
+	if err != nil {
+		return Article{}, err
+	}
+
+	mainImage, err := getMainImageOfArticle(articleSMP)
+	if err != nil {
+		return Article{}, err
+	}
+
+	// Create the article object
+	article := Article{
+		ID: uuid.NullUUID{
+			UUID:  uuid.New(),
+			Valid: true,
+		},
+		Title:      articleSMP.Title.Value,
+		ArticleURL: *tempURL,
+		ImgURL:     *mainImage,
+	}
+
+	return article, nil
+}

--- a/internal/models/quizzes/quizzes.go
+++ b/internal/models/quizzes/quizzes.go
@@ -263,3 +263,14 @@ func UpdateActiveStartByQuizID(db *sql.DB, id uuid.UUID, activeStart time.Time) 
 		id)
 	return err
 }
+
+// Update the quiz's 'active' end time by its ID.
+func UpdateActiveEndByQuizID(db *sql.DB, id uuid.UUID, activeEnd time.Time) error {
+	_, err := db.Exec(
+		`UPDATE quizzes
+		SET available_to = $1
+		WHERE id = $2`,
+		activeEnd,
+		id)
+	return err
+}

--- a/internal/utils/data/data_handling.go
+++ b/internal/utils/data/data_handling.go
@@ -31,7 +31,7 @@ func DateStringToNorwayTime(dateTime string, c echo.Context) (time.Time, error) 
 	// Get the time in Norway's timezone
 	norwayLocation, err := time.LoadLocation("Europe/Oslo")
 	if err != nil {
-		return time.Unix(0, 0), echo.NewHTTPError(http.StatusInternalServerError, "Failed to get Norway's time zone")
+		return time.Unix(0, 0), err
 	}
 
 	// Parse the time

--- a/internal/web_server/web/handlers/api/admin_api.go
+++ b/internal/web_server/web/handlers/api/admin_api.go
@@ -145,14 +145,14 @@ func (aah *AdminApiHandler) editQuizPublished(c echo.Context) error {
 
 	// Update the quiz published status
 	published := c.FormValue(dashboard_pages.QuizPublished)
-	err = quizzes.UpdatePublishedStatusByQuizID(aah.sharedData.DB, quiz_id, !(published == "on"))
+	err = quizzes.UpdatePublishedStatusByQuizID(aah.sharedData.DB, quiz_id, published != "on")
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Failed to update quiz published status")
 	}
 
 	time.Sleep(500 * time.Millisecond) // TODO: Remove
 
-	return utils.Render(c, http.StatusOK, dashboard_components.ToggleQuizPublished(!(published == "on"), quiz_id.String(), dashboard_pages.QuizPublished))
+	return utils.Render(c, http.StatusOK, dashboard_components.ToggleQuizPublished(published != "on", quiz_id.String(), dashboard_pages.QuizPublished))
 }
 
 // Updates the active start time of a quiz in the database.

--- a/internal/web_server/web/handlers/api/admin_api.go
+++ b/internal/web_server/web/handlers/api/admin_api.go
@@ -190,21 +190,21 @@ func (aah *AdminApiHandler) editQuizActiveEnd(c echo.Context) error {
 	}
 
 	// Get the time in Norway's timezone
-	activeEnd := c.FormValue(dashboard_pages.QuizActiveFrom)
+	activeEnd := c.FormValue(dashboard_pages.QuizActiveTo)
 	activeEndTime, err := data_handling.DateStringToNorwayTime(activeEnd, c)
 	if err != nil {
 		return err
 	}
 
-	// Update the quiz active start
-	err = quizzes.UpdateActiveStartByQuizID(aah.sharedData.DB, quiz_id, activeEndTime)
+	// Update the quiz active end
+	err = quizzes.UpdateActiveEndByQuizID(aah.sharedData.DB, quiz_id, activeEndTime)
 	if err != nil {
-		return echo.NewHTTPError(http.StatusBadRequest, "Failed to update quiz active start time")
+		return echo.NewHTTPError(http.StatusBadRequest, "Failed to update quiz active end time")
 	}
 
 	time.Sleep(500 * time.Millisecond) // TODO: Remove
 
-	return utils.Render(c, http.StatusOK, dashboard_components.EditActiveStartInput(activeEndTime, quiz_id.String(), dashboard_pages.QuizActiveFrom))
+	return utils.Render(c, http.StatusOK, dashboard_components.EditActiveEndInput(activeEndTime, quiz_id.String(), dashboard_pages.QuizActiveFrom))
 }
 
 func (aah *AdminApiHandler) addArticleToQuiz(c echo.Context) error {

--- a/internal/web_server/web/handlers/api/admin_api.go
+++ b/internal/web_server/web/handlers/api/admin_api.go
@@ -1,11 +1,13 @@
 package api
 
 import (
+	"database/sql"
 	"net/http"
 	"net/url"
 	"time"
 
 	"github.com/Molnes/Nyhetsjeger/internal/config"
+	"github.com/Molnes/Nyhetsjeger/internal/models/articles"
 	"github.com/Molnes/Nyhetsjeger/internal/models/quizzes"
 	utils "github.com/Molnes/Nyhetsjeger/internal/utils"
 	data_handling "github.com/Molnes/Nyhetsjeger/internal/utils/data"
@@ -38,6 +40,7 @@ func (aah *AdminApiHandler) RegisterAdminApiHandlers(e *echo.Group) {
 	e.POST("/quiz/edit-end", aah.editQuizActiveEnd)
 	e.POST("/quiz/edit-published-status", aah.editQuizPublished)
 	e.DELETE("/quiz/delete-quiz", aah.deleteQuiz)
+	e.POST("/quiz/add-article", aah.addArticleToQuiz)
 }
 
 // Handles the creation of a new default quiz in the DB.
@@ -202,4 +205,55 @@ func (aah *AdminApiHandler) editQuizActiveEnd(c echo.Context) error {
 	time.Sleep(500 * time.Millisecond) // TODO: Remove
 
 	return utils.Render(c, http.StatusOK, dashboard_components.EditActiveStartInput(activeEndTime, quiz_id.String(), dashboard_pages.QuizActiveFrom))
+}
+
+func (aah *AdminApiHandler) addArticleToQuiz(c echo.Context) error {
+	// Get the quiz ID
+	quiz_id, err := uuid.Parse(c.QueryParam(queryParamQuizID))
+	if err != nil {
+		return echo.NewHTTPError(http.StatusBadRequest, errorInvalidQuizID)
+	}
+
+	// Get the article URL
+	articleURL := c.FormValue(dashboard_pages.QuizArticleURL)
+	tempURL, err := url.Parse(articleURL)
+	if err != nil && err == sql.ErrNoRows {
+		return echo.NewHTTPError(http.StatusBadRequest, "Invalid article URL")
+	}
+
+	// Check if the article is already in the DB
+	articleID, err := articles.GetArticleIDByURL(aah.sharedData.DB, tempURL)
+	if err != nil && err != sql.ErrNoRows {
+		return echo.NewHTTPError(http.StatusBadRequest, "Failed to get article ID")
+	}
+
+	// If it exists, check if it already is in the quiz
+	if articleID.Valid {
+		articleInQuiz, err := articles.IsArticleInQuiz(aah.sharedData.DB, &articleID.UUID, &quiz_id)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "Failed to check if article is in quiz")
+		}
+		if articleInQuiz {
+			return echo.NewHTTPError(http.StatusBadRequest, "Article is already in quiz")
+		}
+	}
+
+	// If not in DB, fetch the relevant article data and add it to the DB
+	if !articleID.Valid {
+		article, err := articles.GetArticleByURL(articleURL)
+		if err != nil {
+			return echo.NewHTTPError(http.StatusBadRequest, "Failed to fetch article data")
+		}
+
+		articles.AddArticle(aah.sharedData.DB, &article)
+
+		articleID = &article.ID
+	}
+
+	// Add the article to the quiz
+	err = articles.AddArticleToQuiz(aah.sharedData.DB, &articleID.UUID, &quiz_id)
+
+	time.Sleep(500 * time.Millisecond) // TODO: Remove
+
+	return utils.Render(c, http.StatusOK, dashboard_components.ArticleListItem(articleURL))
 }

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/add_article_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/add_article_input.templ
@@ -1,0 +1,20 @@
+package dashboard_components
+
+// A row with a label and an input field.
+// The input field is for adding a new article to the list of articles.
+templ AddArticleInput(nameInput string) {
+	<div class="flex flex-row gap-5 mb-3">
+		<label for={ nameInput }>
+			Link
+			<input
+				id={ nameInput }
+				name={ nameInput }
+				type="text"
+				class="bg-gray-200 px-2 py-1 ml-3"
+			/>
+		</label>
+		<button hx-post="" class="bg-gray-300 px-5 py-1">
+			Legg til ➕
+		</button>
+	</div>
+}

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/add_article_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/add_article_input.templ
@@ -1,8 +1,12 @@
 package dashboard_components
 
+import (
+	"fmt"
+)
+
 // A row with a label and an input field.
 // The input field is for adding a new article to the list of articles.
-templ AddArticleInput(nameInput string) {
+templ AddArticleInput(articlesLength int, articleNameInput string, quizID string, nameInput string) {
 	<div class="flex flex-row gap-5 mb-3">
 		<label for={ nameInput }>
 			Link
@@ -13,7 +17,14 @@ templ AddArticleInput(nameInput string) {
 				class="bg-gray-200 px-2 py-1 ml-3"
 			/>
 		</label>
-		<button hx-post="" class="bg-gray-300 px-5 py-1">
+		<button
+			class="bg-gray-300 px-5 py-1"
+			hx-post={ fmt.Sprintf("/api/v1/admin/quiz/add-article?quiz-id=%s", quizID) }
+			hx-swap="beforeend"
+			hx-target="#article-list"
+			hx-sync="closest form:abort"
+			hx-indicator="previous .htmx-indicator"
+		>
 			Legg til ➕
 		</button>
 	</div>

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/add_article_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/add_article_input.templ
@@ -16,6 +16,7 @@ templ AddArticleInput(articlesLength int, articleNameInput string, quizID string
 				type="text"
 				class="bg-gray-200 px-2 py-1 ml-3"
 			/>
+			// TODO: Clear the input field on form submitted
 		</label>
 		<button
 			class="bg-gray-300 px-5 py-1"

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_active_end_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_active_end_input.templ
@@ -11,8 +11,9 @@ import (
 // The input has datetime in Norway's timezone.
 templ EditActiveEndInput(endTime time.Time, quizID string, inputName string) {
 	<div id="quiz-active-end" class="block mb-3">
-		<label for="quiz-active-end" class="mr-5">Til</label>
+		<label for={ inputName } class="mr-5">Til</label>
 		<input
+			id={ inputName }
 			name={ inputName }
 			type="datetime-local"
 			class="bg-gray-200 px-3 py-1"
@@ -20,7 +21,7 @@ templ EditActiveEndInput(endTime time.Time, quizID string, inputName string) {
 			hx-post={ fmt.Sprintf("/api/v1/admin/quiz/edit-end?quiz-id=%s", quizID) }
 			hx-trigger="change"
 			hx-target="this"
-			hx-swap="#quiz-active-start"
+			hx-swap="#quiz-active-end"
 			hx-sync="closest form:abort"
 			hx-indicator="previous .htmx-indicator"
 		/>

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_active_start_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_active_start_input.templ
@@ -11,8 +11,9 @@ import (
 // The input has datetime in Norway's timezone.
 templ EditActiveStartInput(startTime time.Time, quizID string, inputName string) {
 	<div id="quiz-active-start" class="block mb-3">
-		<label for="quiz-active-start" class="mr-4">Fra</label>
+		<label for={ inputName } class="mr-4">Fra</label>
 		<input
+			id={ inputName }
 			name={ inputName }
 			type="datetime-local"
 			class="bg-gray-200 px-3 py-1"

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
@@ -18,7 +18,7 @@ templ EditImageInput(imageURL *url.URL, quizID string, inputName string) {
 			value={ imageURL.String() }
 			hx-post={ fmt.Sprintf("/api/v1/admin/quiz/edit-image?quiz-id=%s", quizID) }
 			hx-trigger="change"
-			hx-swap="innerHTML"
+			hx-swap="outerHTML"
 			hx-target="#image-input-wrapper"
 			hx-sync="closest form:abort"
 			hx-indicator="previous .htmx-indicator"

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
@@ -11,7 +11,7 @@ import (
 templ EditImageInput(imageURL *url.URL, quizID string, inputName string) {
 	<div id="image-input-wrapper">
 		<input
-			id="quiz-image"
+			id={ inputName }
 			name={ inputName }
 			class="bg-gray-200 w-full px-2 py-1 mb-2"
 			type="text"

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_title_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_title_input.templ
@@ -9,7 +9,7 @@ import (
 // It will trigger the previous loading indicator to display.
 templ EditTitleInput(quizTitle string, quizID string, inputName string) {
 	<input
-		id="quiz-title"
+		id={ inputName }
 		name={ inputName }
 		class="bg-gray-200 w-full px-2 py-1"
 		type="text"

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/question_list_item.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/question_list_item.templ
@@ -6,6 +6,8 @@ import (
 	"github.com/Molnes/Nyhetsjeger/internal/models/questions"
 )
 
+// An item in the list of questions.
+// Contains the question text and a button to edit the question.
 templ QuestionListItem(question *questions.Question) {
 	<li class="flex flex-row justify-between px-3 py-1">
 		{ question.Text }

--- a/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
+++ b/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
@@ -14,6 +14,7 @@ import (
 const QuizTitle = "quiz-title"
 const QuizImageURL = "quiz-image-url"
 const QuizPublished = "quiz-is-published"
+const QuizArticleURL = "quiz-article-url"
 const QuizActiveFrom = "quiz-active-from"
 const QuizActiveTo = "quiz-active-to"
 
@@ -26,7 +27,7 @@ templ EditQuiz(quiz *quizzes.Quiz, articles *[]articles.Article) {
 			// Quiz Title
 			@dashboard_components.EditQuizForm(fmt.Sprintf("/api/v1/admin/quiz/edit-title?quiz-id=%s", quiz.ID)) {
 				<div class="flex flex-row items-center gap-3">
-					<label for="quiz-title" class="block">Tittel</label>
+					<label for={ QuizTitle } class="block">Tittel</label>
 					@components.LoadingIndicator()
 				</div>
 				@dashboard_components.EditTitleInput(quiz.Title, quiz.ID.String(), QuizTitle)
@@ -34,7 +35,7 @@ templ EditQuiz(quiz *quizzes.Quiz, articles *[]articles.Article) {
 			// Quiz Image
 			@dashboard_components.EditQuizForm(fmt.Sprintf("/api/v1/admin/quiz/edit-image?quiz-id=%s", quiz.ID)) {
 				<div class="flex flex-row items-center gap-3">
-					<label for="quiz-title" class="block">Forside bilde</label>
+					<label for={ QuizImageURL } class="block">Forside bilde</label>
 					@components.LoadingIndicator()
 				</div>
 				// TODO: Also support uploading an image
@@ -47,12 +48,7 @@ templ EditQuiz(quiz *quizzes.Quiz, articles *[]articles.Article) {
 					<h2>Artikler i quizzen</h2>
 					@components.LoadingIndicator()
 				</div>
-				<div class="flex flex-row gap-5 mb-3">
-					<label for="add-article">Link<input type="text" id="add-article" class="bg-gray-200 px-2 py-1 ml-3"/></label>
-					<button hx-post="" id="add-article" class="bg-gray-300 px-5 py-1">
-						Legg til ➕
-					</button>
-				</div>
+				@dashboard_components.AddArticleInput(QuizArticleURL)
 				// List of all articles
 				<ul id="article-list" class="w-full bg-gray-300 [&>*:nth-child(odd)]:bg-gray-200">
 					if len(*articles) == 0 {

--- a/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
+++ b/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
@@ -52,15 +52,23 @@ templ EditQuiz(quiz *quizzes.Quiz, articles *[]articles.Article) {
 				@dashboard_components.AddArticleInput(len(*articles), ArticlesLength, quiz.ID.String(), QuizArticleURL)
 				// List of all articles
 				<ul id="article-list" class="w-full bg-gray-300 [&>*:nth-child(odd)]:bg-gray-200">
-					if len(*articles) == 0 {
-						<li class="text-center px-2 py-4">Ingen artikler lagt til enda.</li>
-					}
+					<li
+						id="no-articles-warning"
+						if len(*articles) == 0 {
+							class="text-center px-2 py-4"
+						} else {
+							class="text-center px-2 py-4 hidden"
+						}
+					>
+						<p>Ingen artikler lagt til enda.</p>
+					</li>
 					for _, article := range *articles {
 						if article.ID.Valid {
 							@dashboard_components.ArticleListItem(article.ArticleURL.String())
 						}
 					}
 				</ul>
+				@articleList()
 			}
 			// Quiz Active Time
 			@dashboard_components.EditQuizForm("") {
@@ -130,4 +138,37 @@ script modalWindowScript() {
 		}
 
 		newQuestionButton.addEventListener("click", openQuestionModal);
+}
+
+// This script is used to observe changes in the article list.
+// If the warning is displayed and  an article is added, hide the warning.
+// If the last article is removed, the warning should be shown.
+
+script articleList() {
+		const articleList = document.getElementById("article-list");
+		const noArticlesWarning = document.getElementById("no-articles-warning");
+
+		// Observe if the children of article list are mutated (added or removed)
+		const observer = new MutationObserver(handleChanges);
+		const config = { childList: true };
+		observer.observe(articleList, config);
+
+		// If the article list is changed, this function is called
+		function handleChanges(mutationsList, observer) {
+				mutationsList.forEach(mutation => {
+						if (mutation.type === 'childList') {
+								updateWarningVisibility();
+						}
+				});
+		}
+
+		// Update if the warning should be shown or not
+		const updateWarningVisibility = () => {
+			// If the warning is shown, but an article is appended, hide the warning
+			if (noArticlesWarning && articleList.children.length > 1) {
+				noArticlesWarning.classList.add("hidden");
+			} else if (noArticlesWarning) {
+				noArticlesWarning.classList.remove("hidden");
+			}
+		}
 }

--- a/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
+++ b/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
@@ -17,6 +17,7 @@ const QuizPublished = "quiz-is-published"
 const QuizArticleURL = "quiz-article-url"
 const QuizActiveFrom = "quiz-active-from"
 const QuizActiveTo = "quiz-active-to"
+const ArticlesLength = "articles-length"
 
 // The "Edit quiz" page. This page is used to edit a quiz.
 // Add title, image, articles, active time, questions and answers.
@@ -43,12 +44,12 @@ templ EditQuiz(quiz *quizzes.Quiz, articles *[]articles.Article) {
 				@dashboard_components.EditImageInput(&quiz.ImageURL, quiz.ID.String(), QuizImageURL)
 			}
 			// Quiz Articles
-			@dashboard_components.EditQuizForm("") {
+			@dashboard_components.EditQuizForm(fmt.Sprintf("/api/v1/admin/quiz/add-article?quiz-id=%s", quiz.ID)) {
 				<div class="flex flex-row items-center gap-3">
 					<h2>Artikler i quizzen</h2>
 					@components.LoadingIndicator()
 				</div>
-				@dashboard_components.AddArticleInput(QuizArticleURL)
+				@dashboard_components.AddArticleInput(len(*articles), ArticlesLength, quiz.ID.String(), QuizArticleURL)
 				// List of all articles
 				<ul id="article-list" class="w-full bg-gray-300 [&>*:nth-child(odd)]:bg-gray-200">
 					if len(*articles) == 0 {


### PR DESCRIPTION
Admin adds link to quiz. Check if article already exists. If yes: add it to quiz. If no: create article and add it to quiz. To create a new article, it will currently read the JSON file with the filename that is the same as ID. I.e. if link has `/i/abc` then the file must be `abc.json`. If admin attempts to add link that already exists for the quiz, do nothing (return 

Also fixed an issue with quiz' active end not updating.