### PR TITLE
Create question and add to quiz

### DIFF
--- a/db/migrations/000001_init.up.sql
+++ b/db/migrations/000001_init.up.sql
@@ -95,8 +95,13 @@ CREATE TABLE IF NOT EXISTS answer_alternatives (
 CREATE OR REPLACE FUNCTION insert_quiz_articles()
 RETURNS TRIGGER AS $$
 BEGIN
-    -- If the article_id is not null, insert a new entry
-    IF NEW.article_id IS NOT NULL THEN
+    -- If the article_id is not null and the quiz_article combo does not already exist, insert a new entry
+    IF NEW.article_id IS NOT NULL AND NOT EXISTS (
+        SELECT 1
+        FROM quiz_articles
+        WHERE quiz_id = NEW.quiz_id AND article_id = NEW.article_id
+    )
+    THEN
         INSERT INTO quiz_articles (quiz_id, article_id) VALUES (NEW.quiz_id, NEW.article_id);
     END IF;
 

--- a/internal/models/articles/articles.go
+++ b/internal/models/articles/articles.go
@@ -9,10 +9,10 @@ import (
 )
 
 type Article struct {
-	ID         uuid.NullUUID
-	Title      string
-	ArticleURL url.URL
-	ImgURL     url.URL
+	ID         uuid.NullUUID // The ID of the article.
+	Title      string        // The title of the article.
+	ArticleURL url.URL       // The URL of the article.
+	ImgURL     url.URL       // The URL of the main image of the article.
 }
 
 func newArticleNoID(title string, articleURL url.URL, imgURL url.URL) Article {
@@ -156,21 +156,18 @@ func scanArticlesFromFullRows(rows *sql.Rows) (*[]Article, error) {
 	return &articles, nil
 }
 
-// Get an Article ID by its URL.
-func GetArticleIDByURL(db *sql.DB, articleURL *url.URL) (*uuid.NullUUID, error) {
+// Get an Article by its URL from database.
+func GetArticleByURL(db *sql.DB, articleURL *url.URL) (*Article, error) {
 	row := db.QueryRow(
 		`SELECT
-			id
+		id, title, url, image_url
 		FROM
 			articles
 		WHERE
 			url = $1`,
 		articleURL.String())
 
-	var articleID uuid.NullUUID
-	err := row.Scan(&articleID)
-
-	return &articleID, err
+	return scanArticleFromFullRow(row)
 }
 
 // Add an Article to the database.

--- a/internal/models/articles/third_party_articles.go
+++ b/internal/models/articles/third_party_articles.go
@@ -112,8 +112,8 @@ func getMainImageOfArticle(article ArticleSMP) (*url.URL, error) {
 	return &url.URL{}, nil
 }
 
-// Get an Article by its URL.
-func GetArticleByURL(articleUrl string) (Article, error) {
+// Get an SMP Article by its URL.
+func GetSmpArticleByURL(articleUrl string) (Article, error) {
 	// TODO: Update this to fetch the article from the web instead of reading it from JSON.
 
 	// Get article's SMP ID
@@ -134,6 +134,7 @@ func GetArticleByURL(articleUrl string) (Article, error) {
 		return Article{}, err
 	}
 
+	// Get the main image of the article
 	mainImage, err := getMainImageOfArticle(articleSMP)
 	if err != nil {
 		return Article{}, err

--- a/internal/models/questions/questions.go
+++ b/internal/models/questions/questions.go
@@ -388,7 +388,8 @@ func ParseAndValidateQuestionData(questionText string, questionPoints string, ar
 }
 
 // Create a question object from a form.
-func CreateQuestionFromForm(form QuestionForm) Question {
+// Returns the created question and an error message.
+func CreateQuestionFromForm(form QuestionForm) (Question, string) {
 	questionID := uuid.New()
 
 	question := Question{
@@ -401,6 +402,8 @@ func CreateQuestionFromForm(form QuestionForm) Question {
 		Alternatives: []Alternative{},
 	}
 
+	hasCorrectAlternative := false
+
 	// Only add alternatives that are not empty
 	for index, alt := range []string{form.Alternative1, form.Alternative2, form.Alternative3, form.Alternative4} {
 		if alt != "" {
@@ -409,10 +412,27 @@ func CreateQuestionFromForm(form QuestionForm) Question {
 				Text:      alt,
 				IsCorrect: form.Alternative1 == strconv.Itoa(index+1),
 			})
+
+			if form.CorrectAnswerNumber == strconv.Itoa(index+1) {
+				hasCorrectAlternative = true
+			}
 		}
 	}
 
-	return question
+	// Check that there is a correct alternative
+	if !hasCorrectAlternative {
+		return question, "Question has no correct alternative"
+	}
+
+	// Check that there are two to four alternatives
+	if len(question.Alternatives) < 2 {
+		return question, "There must be at least two alternatives"
+	}
+	if len(question.Alternatives) > 4 {
+		return question, "There can be at most four alternatives"
+	}
+
+	return question, ""
 }
 
 // Add a new question to the database.

--- a/internal/models/questions/questions.go
+++ b/internal/models/questions/questions.go
@@ -392,38 +392,24 @@ func CreateQuestionFromForm(form QuestionForm) Question {
 	questionID := uuid.New()
 
 	question := Question{
-		ID:       questionID,
-		Text:     form.Text,
-		ImageURL: *form.ImageURL,
-		Article:  *form.Article,
-		QuizID:   *form.QuizID,
-		Points:   form.Points,
-		Alternatives: []Alternative{
-			{
-				ID:         uuid.New(),
-				Text:       form.Alternative1,
-				IsCorrect:  form.CorrectAnswerNumber == "1",
-				QuestionID: questionID,
-			},
-			{
-				ID:         uuid.New(),
-				Text:       form.Alternative2,
-				IsCorrect:  form.CorrectAnswerNumber == "2",
-				QuestionID: questionID,
-			},
-			{
-				ID:         uuid.New(),
-				Text:       form.Alternative3,
-				IsCorrect:  form.CorrectAnswerNumber == "3",
-				QuestionID: questionID,
-			},
-			{
-				ID:         uuid.New(),
-				Text:       form.Alternative4,
-				IsCorrect:  form.CorrectAnswerNumber == "4",
-				QuestionID: questionID,
-			},
-		},
+		ID:           questionID,
+		Text:         form.Text,
+		ImageURL:     *form.ImageURL,
+		Article:      *form.Article,
+		QuizID:       *form.QuizID,
+		Points:       form.Points,
+		Alternatives: []Alternative{},
+	}
+
+	// Only add alternatives that are not empty
+	for index, alt := range []string{form.Alternative1, form.Alternative2, form.Alternative3, form.Alternative4} {
+		if alt != "" {
+			question.Alternatives = append(question.Alternatives, Alternative{
+				ID:        uuid.New(),
+				Text:      alt,
+				IsCorrect: form.Alternative1 == strconv.Itoa(index+1),
+			})
+		}
 	}
 
 	return question

--- a/internal/web_server/web/handlers/api/admin_api.go
+++ b/internal/web_server/web/handlers/api/admin_api.go
@@ -2,6 +2,7 @@ package api
 
 import (
 	"database/sql"
+	"fmt"
 	"net/http"
 	"net/url"
 	"time"
@@ -32,7 +33,7 @@ func NewAdminApiHandler(sharedData *config.SharedData) *AdminApiHandler {
 
 // Registers handlers for admin api
 func (aah *AdminApiHandler) RegisterAdminApiHandlers(e *echo.Group) {
-	e.POST("/quiz/create-new", aah.postDefaultQuiz)
+	e.POST("/quiz/create-new", aah.createDefaultQuiz)
 	e.POST("/quiz/edit-title", aah.editQuizTitle)
 	e.POST("/quiz/edit-image", aah.editQuizImage)
 	e.DELETE("/quiz/edit-image", aah.deleteQuizImage)
@@ -42,11 +43,12 @@ func (aah *AdminApiHandler) RegisterAdminApiHandlers(e *echo.Group) {
 	e.DELETE("/quiz/delete-quiz", aah.deleteQuiz)
 	e.POST("/quiz/add-article", aah.addArticleToQuiz)
 	e.DELETE("/quiz/delete-article", aah.deleteArticle)
+	e.POST("/question/create-new", aah.createQuestion)
 }
 
 // Handles the creation of a new default quiz in the DB.
 // Redirects to the edit quiz page for the newly created quiz.
-func (aah *AdminApiHandler) postDefaultQuiz(c echo.Context) error {
+func (aah *AdminApiHandler) createDefaultQuiz(c echo.Context) error {
 	// Create a default quiz object
 	quiz := quizzes.CreateDefaultQuiz()
 
@@ -98,7 +100,7 @@ func (aah *AdminApiHandler) editQuizImage(c echo.Context) error {
 
 	time.Sleep(500 * time.Millisecond) // TODO: Remove
 
-	return utils.Render(c, http.StatusOK, dashboard_components.EditImageInput(imageURL, quiz_id.String(), dashboard_pages.QuizImageURL))
+	return utils.Render(c, http.StatusOK, dashboard_components.EditImageInput(fmt.Sprintf("/api/v1/admin/quiz/edit-image?quiz-id=%s", quiz_id), imageURL, dashboard_pages.QuizImageURL, true))
 }
 
 // Removes the image for a quiz in the database.
@@ -117,7 +119,8 @@ func (dph *AdminApiHandler) deleteQuizImage(c echo.Context) error {
 
 	time.Sleep(500 * time.Millisecond) // TODO: Remove
 
-	return utils.Render(c, http.StatusOK, dashboard_components.EditImageInput(&url.URL{}, quiz_id.String(), dashboard_pages.QuizImageURL))
+	return utils.Render(c, http.StatusOK,
+		dashboard_components.EditImageInput(fmt.Sprintf("/api/v1/admin/quiz/edit-image?quiz-id=%s", quiz_id), &url.URL{}, dashboard_pages.QuizImageURL, true))
 }
 
 // Deletes a quiz from the database.
@@ -130,6 +133,8 @@ func (aah *AdminApiHandler) deleteQuiz(c echo.Context) error {
 
 	// Sets the quiz as deleted in the database
 	quizzes.DeleteQuizByID(aah.sharedData.DB, quiz_id)
+
+	time.Sleep(500 * time.Millisecond) // TODO: Remove
 
 	c.Response().Header().Set("HX-Redirect", "/dashboard")
 	return c.Redirect(http.StatusOK, "/dashboard")
@@ -282,4 +287,16 @@ func (aah *AdminApiHandler) deleteArticle(c echo.Context) error {
 	time.Sleep(500 * time.Millisecond) // TODO: Remove
 
 	return c.NoContent(http.StatusOK)
+}
+
+// Creates a new question in the database with the given data.
+func (aah *AdminApiHandler) createQuestion(c echo.Context) error {
+	// Get the data from the form
+
+	// Create a new question object
+
+	// Save the question to the database
+
+	// Return the "question item" element
+	return utils.Render(c, http.StatusOK, nil)
 }

--- a/internal/web_server/web/handlers/api/admin_api.go
+++ b/internal/web_server/web/handlers/api/admin_api.go
@@ -340,7 +340,10 @@ func (aah *AdminApiHandler) createQuestion(c echo.Context) error {
 		Alternative3:        alternative3,
 		Alternative4:        alternative4,
 	}
-	question := questions.CreateQuestionFromForm(questionForm)
+	question, errorText := questions.CreateQuestionFromForm(questionForm)
+	if errorText != "" {
+		return echo.NewHTTPError(http.StatusBadRequest, errorText)
+	}
 
 	// Save the question to the database
 	err = questions.AddNewQuestion(aah.sharedData.DB, question)

--- a/internal/web_server/web/handlers/api/admin_api.go
+++ b/internal/web_server/web/handlers/api/admin_api.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net/http"
 	"net/url"
-	"time"
 
 	"github.com/Molnes/Nyhetsjeger/internal/config"
 	"github.com/Molnes/Nyhetsjeger/internal/models/articles"
@@ -78,8 +77,6 @@ func (aah *AdminApiHandler) editQuizTitle(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Failed to update quiz title")
 	}
 
-	time.Sleep(500 * time.Millisecond) // TODO: Remove
-
 	return utils.Render(c, http.StatusOK, dashboard_components.EditTitleInput(title, quiz_id.String(), dashboard_pages.QuizTitle))
 }
 
@@ -99,8 +96,6 @@ func (aah *AdminApiHandler) editQuizImage(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Failed to update quiz image")
 	}
 
-	time.Sleep(500 * time.Millisecond) // TODO: Remove
-
 	return utils.Render(c, http.StatusOK, dashboard_components.EditImageInput(fmt.Sprintf("/api/v1/admin/quiz/edit-image?quiz-id=%s", quiz_id), imageURL, dashboard_pages.QuizImageURL, true))
 }
 
@@ -118,8 +113,6 @@ func (dph *AdminApiHandler) deleteQuizImage(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Failed to remove quiz image")
 	}
 
-	time.Sleep(500 * time.Millisecond) // TODO: Remove
-
 	return utils.Render(c, http.StatusOK,
 		dashboard_components.EditImageInput(fmt.Sprintf("/api/v1/admin/quiz/edit-image?quiz-id=%s", quiz_id), &url.URL{}, dashboard_pages.QuizImageURL, true))
 }
@@ -134,8 +127,6 @@ func (aah *AdminApiHandler) deleteQuiz(c echo.Context) error {
 
 	// Sets the quiz as deleted in the database
 	quizzes.DeleteQuizByID(aah.sharedData.DB, quiz_id)
-
-	time.Sleep(500 * time.Millisecond) // TODO: Remove
 
 	c.Response().Header().Set("HX-Redirect", "/dashboard")
 	return c.Redirect(http.StatusOK, "/dashboard")
@@ -156,8 +147,6 @@ func (aah *AdminApiHandler) editQuizPublished(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Failed to update quiz published status")
 	}
-
-	time.Sleep(500 * time.Millisecond) // TODO: Remove
 
 	return utils.Render(c, http.StatusOK, dashboard_components.ToggleQuizPublished(published != "on", quiz_id.String(), dashboard_pages.QuizPublished))
 }
@@ -183,8 +172,6 @@ func (aah *AdminApiHandler) editQuizActiveStart(c echo.Context) error {
 		return echo.NewHTTPError(http.StatusBadRequest, "Failed to update quiz active start time")
 	}
 
-	time.Sleep(500 * time.Millisecond) // TODO: Remove
-
 	return utils.Render(c, http.StatusOK, dashboard_components.EditActiveStartInput(activeStartTime, quiz_id.String(), dashboard_pages.QuizActiveFrom))
 }
 
@@ -208,8 +195,6 @@ func (aah *AdminApiHandler) editQuizActiveEnd(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Failed to update quiz active end time")
 	}
-
-	time.Sleep(500 * time.Millisecond) // TODO: Remove
 
 	return utils.Render(c, http.StatusOK, dashboard_components.EditActiveEndInput(activeEndTime, quiz_id.String(), dashboard_pages.QuizActiveFrom))
 }
@@ -274,8 +259,6 @@ func (aah *AdminApiHandler) addArticleToQuiz(c echo.Context) error {
 	// Add the article to the quiz
 	err = articles.AddArticleToQuiz(aah.sharedData.DB, &article.ID.UUID, &quiz_id)
 
-	time.Sleep(500 * time.Millisecond) // TODO: Remove
-
 	return utils.Render(c, http.StatusOK, dashboard_components.ArticleListItem(articleURL, article.ID.UUID.String(), quiz_id.String()))
 }
 
@@ -298,8 +281,6 @@ func (aah *AdminApiHandler) deleteArticle(c echo.Context) error {
 	if err != nil {
 		return echo.NewHTTPError(http.StatusBadRequest, "Failed to delete article from quiz")
 	}
-
-	time.Sleep(500 * time.Millisecond) // TODO: Remove
 
 	return c.NoContent(http.StatusOK)
 }

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/add_article_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/add_article_input.templ
@@ -7,14 +7,14 @@ import (
 // A row with a label and an input field.
 // The input field is for adding a new article to the list of articles.
 templ AddArticleInput(articlesLength int, articleNameInput string, quizID string, nameInput string) {
-	<div class="flex flex-row gap-5 mb-3">
+	<div class="flex flex-row flex-wrap gap-5 mb-3">
 		<label for={ nameInput }>
-			Link
+			Link&ensp;
 			<input
 				id={ nameInput }
 				name={ nameInput }
 				type="text"
-				class="bg-gray-200 px-2 py-1 ml-3"
+				class="bg-gray-200 px-2 py-1"
 			/>
 		</label>
 		<button

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
@@ -1,14 +1,13 @@
 package dashboard_components
 
 import (
-	"fmt"
 	"net/url"
 )
 
-// An input field for editing the image of a quiz.
-// When the value is changed, send a POST request to the server to update the image.
+// An input field for updating the image.
+// When the value is changed, send a POST request to the given URL for updating the image.
 // It will trigger the previous loading indicator to display.
-templ EditImageInput(imageURL *url.URL, quizID string, inputName string) {
+templ EditImageInput(requestURL string, imageURL *url.URL, inputName string, post bool) {
 	<div id="image-input-wrapper">
 		<input
 			id={ inputName }
@@ -16,13 +15,31 @@ templ EditImageInput(imageURL *url.URL, quizID string, inputName string) {
 			class="bg-gray-200 w-full px-2 py-1 mb-2"
 			type="text"
 			value={ imageURL.String() }
-			hx-post={ fmt.Sprintf("/api/v1/admin/quiz/edit-image?quiz-id=%s", quizID) }
-			hx-trigger="change"
-			hx-swap="outerHTML"
-			hx-target="#image-input-wrapper"
-			hx-sync="closest form:abort"
-			hx-indicator="previous .htmx-indicator"
+			if post {
+				hx-post={ requestURL }
+				hx-trigger="change"
+				hx-swap="outerHTML"
+				hx-target="#image-input-wrapper"
+				hx-sync="closest form:abort"
+				hx-indicator="previous .htmx-indicator"
+			}
 		/>
-		@ImagePreview(imageURL, quizID)
+		if imageURL.String() == "" {
+			<p class="text-sm text-gray-500">Ingen bilde valgt enda.</p>
+		} else {
+			// This div wrapper is to prevent a layout shift while loading the image
+			<div style="height: 200px" class="mx-auto mb-2">
+				<img src={ imageURL.String() } height="200" style="height: 100%" class="block rounded-lg mx-auto object-cover"/>
+			</div>
+			<button
+				id="remove-image-button"
+				type="button"
+				class="bg-gray-100 px-3 py-2 block mx-auto"
+				hx-delete={ requestURL }
+				hx-swap="outerHTML"
+				hx-target="#image-input-wrapper"
+				hx-indicator="previous .htmx-indicator"
+			>Fjern bilde</button>
+		}
 	</div>
 }

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_question_form.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_question_form.templ
@@ -5,30 +5,45 @@ import (
 
 	"github.com/Molnes/Nyhetsjeger/internal/models/articles"
 	"github.com/Molnes/Nyhetsjeger/internal/models/questions"
+	"github.com/Molnes/Nyhetsjeger/internal/web_server/web/views/components"
 )
+
+// Constants for the input names (for HTTP requests)
+const QuestionArticle = "question-article"
+const QuestionText = "question-text"
+const QuestionAlternative1 = "question-alternative-1"
+const QuestionAlternative2 = "question-alternative-2"
+const QuestionAlternative3 = "question-alternative-3"
+const QuestionAlternative4 = "question-alternative-4"
+const QuestionImageURL = "question-image-url"
+const QuestionPoints = "question-points"
 
 // The form includes a list of articles to base the question on, the question itself,
 // 4 answer alternatives (optional 2 to 4), and an image.
 templ EditQuestionForm(question questions.Question, articles *[]articles.Article, quizID string) {
-	<form hx-post="">
-		<h2 class="text-2xl mb-5">Rediger spørsmål</h2>
+	<form hx-post="" onsubmit="event.preventDefault();">
+		<div class="flex flex-row items-center gap-3">
+			<h2 class="text-2xl mb-5">Rediger spørsmål</h2>
+			@components.LoadingIndicator()
+		</div>
 		// Article
 		<label for="articles-list" class="block">Basert på artikkel (URL)</label>
-		<input list="articles" id="articles-list" class="bg-gray-200 px-3 py-1 w-full mb-5"/>
+		<input id="articles-list" name={ QuestionArticle } list="articles" class="bg-gray-200 px-3 py-1 w-full mb-5"/>
 		<datalist id="articles">
 			for _, article := range *articles {
 				<option value={ article.ArticleURL.String() }></option>
 			}
 		</datalist>
-		// Questions
+		// Question
 		<label for="question" class="block">Spørsmål</label>
-		<input type="text" id="question" class="bg-gray-200 px-3 py-1 w-full mb-5" value={ question.Text }/>
+		<input id="question" name={ QuestionText } type="text" class="bg-gray-200 px-3 py-1 w-full mb-5" value={ question.Text }/>
 		<fieldset class="block mb-5">
 			// Alternatives
 			<legend>Svar alternativer (Fyll inn mellom 2 til 4)</legend>
 			// TODO: Possibly do this better
 			<input
 				id="question-1"
+				name={ QuestionAlternative1 }
 				type="text"
 				class="bg-gray-200 px-3 py-1 w-full mb-2"
 				if len(question.Alternatives) >= 1 {
@@ -37,6 +52,7 @@ templ EditQuestionForm(question questions.Question, articles *[]articles.Article
 			/>
 			<input
 				id="question-2"
+				name={ QuestionAlternative2 }
 				type="text"
 				class="bg-gray-200 px-3 py-1 w-full mb-2"
 				if len(question.Alternatives) >= 2 {
@@ -45,6 +61,7 @@ templ EditQuestionForm(question questions.Question, articles *[]articles.Article
 			/>
 			<input
 				id="question-3"
+				name={ QuestionAlternative3 }
 				type="text"
 				class="bg-gray-200 px-3 py-1 w-full mb-2"
 				if len(question.Alternatives) >= 3 {
@@ -53,6 +70,7 @@ templ EditQuestionForm(question questions.Question, articles *[]articles.Article
 			/>
 			<input
 				id="question-4"
+				name={ QuestionAlternative4 }
 				type="text"
 				class="bg-gray-200 px-3 py-1 w-full"
 				if len(question.Alternatives) >= 4 {
@@ -62,15 +80,35 @@ templ EditQuestionForm(question questions.Question, articles *[]articles.Article
 		</fieldset>
 		// Image
 		<label for="question-image" class="block">Bilde</label>
-		<input id="question-image" type="file" accept="image/png, image/jpg, image/jpeg, image/webp" class="bg-gray-100 p-3 w-full [&:hover]:cursor-pointer mb-2"/>
-		@ImagePreview(&question.ImageURL, quizID)
+		@EditImageInput(fmt.Sprintf("/api/v1/admin/question/edit-image?question-id=%s", question.ID), &question.ImageURL, QuestionImageURL, false)
 		// Points
 		<label for="points" class="block mt-5">Poeng</label>
-		<input id="points" type="number" class="bg-gray-200 px-3 py-1 w-full mb-5" min="0" value={ fmt.Sprint(question.Points) }/>
+		<input
+			id="points"
+			name={ QuestionPoints }
+			type="number"
+			class="bg-gray-200 px-3 py-1 w-full mb-5"
+			min="0"
+			value={ fmt.Sprint(question.Points) }
+		/>
 		// Buttons
 		<div class="flex flex-row justify-between gap-5 mt-5">
-			<button id="close-modal-button" onclick="closeModal()" type="button" class="bg-gray-100 hover:bg-red-400 focus:bg-red-400 font-bold px-3 py-2 w-full">Avbryt</button>
-			<button id="submit-question-button" type="submit" class="bg-gray-200 hover:bg-gray-400 focus:bg-gray-400 font-bold px-3 py-2 w-full">Lagre</button>
+			<button
+				id="close-modal-button"
+				onclick="closeModal()"
+				type="button"
+				class="bg-gray-100 hover:bg-red-400 focus:bg-red-400 font-bold px-3 py-2 w-full"
+			>Avbryt</button>
+			<button
+				id="submit-question-button"
+				type="submit"
+				class="bg-gray-200 hover:bg-gray-400 focus:bg-gray-400 font-bold px-3 py-2 w-full"
+				hx-post={ fmt.Sprintf("/api/v1/admin/question/create-new?quiz-id=%s", quizID) }
+				hx-swap="beforeend"
+				hx-target="#question-list"
+				hx-sync="closest form:abort"
+				hx-indicator="previous .htmx-indicator"
+			>Lagre</button>
 		</div>
 	</form>
 	<script>

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_question_form.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_question_form.templ
@@ -22,9 +22,9 @@ const QuestionPoints = "question-points"
 // The form includes a list of articles to base the question on, the question itself,
 // 4 answer alternatives (optional 2 to 4), and an image.
 templ EditQuestionForm(question questions.Question, articles *[]articles.Article, quizID string) {
-	<form hx-post="" onsubmit="event.preventDefault();">
-		<div class="flex flex-row items-center gap-3">
-			<h2 class="text-2xl mb-5">Rediger spørsmål</h2>
+	<form id="edit-question-form">
+		<div class="flex flex-row items-center gap-3 mb-5">
+			<h2 class="text-2xl">Rediger spørsmål</h2>
 			@components.LoadingIndicator()
 		</div>
 		// Article
@@ -150,9 +150,29 @@ templ EditQuestionForm(question questions.Question, articles *[]articles.Article
 		</div>
 	</form>
 	<script>
+		// Prevent form submission by default
+    const inputs = document.querySelectorAll('#edit-question-form input');
+
+    // Add event listener to each input element
+    inputs.forEach(input => {
+        input.addEventListener('keydown', function(event) {
+            if (event.key === 'Enter') {
+                event.preventDefault();
+            }
+        });
+    });
+
+		// Close the modal
 		function closeModal() {
 			const modal = document.getElementById("question-modal");
 			modal.close();
 		}
+
+		// Close the modal after successful submit
+		document.body.addEventListener("htmx:afterSwap", (event) => {
+			if (event.detail.target.id === "question-list") {
+				closeModal();
+			}
+		});
 	</script>
 }

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_question_form.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_question_form.templ
@@ -9,12 +9,13 @@ import (
 )
 
 // Constants for the input names (for HTTP requests)
-const QuestionArticle = "question-article"
+const QuestionArticleURL = "question-article-url"
 const QuestionText = "question-text"
 const QuestionAlternative1 = "question-alternative-1"
 const QuestionAlternative2 = "question-alternative-2"
 const QuestionAlternative3 = "question-alternative-3"
 const QuestionAlternative4 = "question-alternative-4"
+const QuestionCorrectAlternative = "correct-alternative"
 const QuestionImageURL = "question-image-url"
 const QuestionPoints = "question-points"
 
@@ -28,7 +29,7 @@ templ EditQuestionForm(question questions.Question, articles *[]articles.Article
 		</div>
 		// Article
 		<label for="articles-list" class="block">Basert på artikkel (URL)</label>
-		<input id="articles-list" name={ QuestionArticle } list="articles" class="bg-gray-200 px-3 py-1 w-full mb-5"/>
+		<input id="articles-list" name={ QuestionArticleURL } list="articles" class="bg-gray-200 px-3 py-1 w-full mb-5"/>
 		<datalist id="articles">
 			for _, article := range *articles {
 				<option value={ article.ArticleURL.String() }></option>
@@ -39,44 +40,81 @@ templ EditQuestionForm(question questions.Question, articles *[]articles.Article
 		<input id="question" name={ QuestionText } type="text" class="bg-gray-200 px-3 py-1 w-full mb-5" value={ question.Text }/>
 		<fieldset class="block mb-5">
 			// Alternatives
-			<legend>Svar alternativer (Fyll inn mellom 2 til 4)</legend>
 			// TODO: Possibly do this better
-			<input
-				id="question-1"
-				name={ QuestionAlternative1 }
-				type="text"
-				class="bg-gray-200 px-3 py-1 w-full mb-2"
-				if len(question.Alternatives) >= 1 {
-					value={ question.Alternatives[0].Text }
-				}
-			/>
-			<input
-				id="question-2"
-				name={ QuestionAlternative2 }
-				type="text"
-				class="bg-gray-200 px-3 py-1 w-full mb-2"
-				if len(question.Alternatives) >= 2 {
-					value={ question.Alternatives[1].Text }
-				}
-			/>
-			<input
-				id="question-3"
-				name={ QuestionAlternative3 }
-				type="text"
-				class="bg-gray-200 px-3 py-1 w-full mb-2"
-				if len(question.Alternatives) >= 3 {
-					value={ question.Alternatives[2].Text }
-				}
-			/>
-			<input
-				id="question-4"
-				name={ QuestionAlternative4 }
-				type="text"
-				class="bg-gray-200 px-3 py-1 w-full"
-				if len(question.Alternatives) >= 4 {
-					value={ question.Alternatives[3].Text }
-				}
-			/>
+			<table>
+				<thead>
+					<tr>
+						<th class="w-full text-left">Svar alternativer (Fyll inn mellom 2 til 4)</th>
+						<th class="text-right">Riktig svar</th>
+					</tr>
+				</thead>
+				<tbody>
+					<tr>
+						<td>
+							<input
+								id="question-1"
+								name={ QuestionAlternative1 }
+								type="text"
+								class="bg-gray-200 px-3 py-1 w-full my-1"
+								if len(question.Alternatives) >= 1 {
+									value={ question.Alternatives[0].Text }
+								}
+							/>
+						</td>
+						<td>
+							<input type="radio" name={ QuestionCorrectAlternative } value="1" class="block ml-auto mr-0" checked/>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<input
+								id="question-2"
+								name={ QuestionAlternative2 }
+								type="text"
+								class="bg-gray-200 px-3 py-1 w-full my-1"
+								if len(question.Alternatives) >= 2 {
+									value={ question.Alternatives[1].Text }
+								}
+							/>
+						</td>
+						<td>
+							<input type="radio" name={ QuestionCorrectAlternative } value="2" class="block ml-auto mr-0"/>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<input
+								id="question-3"
+								name={ QuestionAlternative3 }
+								type="text"
+								class="bg-gray-200 px-3 py-1 w-full my-1"
+								if len(question.Alternatives) >= 3 {
+									value={ question.Alternatives[2].Text }
+								}
+							/>
+						</td>
+						<td>
+							<input type="radio" name={ QuestionCorrectAlternative } value="3" class="block ml-auto mr-0"/>
+						</td>
+					</tr>
+					<tr>
+						<td>
+							<input
+								id="question-4"
+								name={ QuestionAlternative4 }
+								type="text"
+								class="bg-gray-200 px-3 py-1 w-full my-1"
+								if len(question.Alternatives) >= 4 {
+									value={ question.Alternatives[3].Text }
+								}
+							/>
+						</td>
+						<td>
+							<input type="radio" name={ QuestionCorrectAlternative } value="4" class="block ml-auto mr-0"/>
+						</td>
+					</tr>
+				</tbody>
+			</table>
 		</fieldset>
 		// Image
 		<label for="question-image" class="block">Bilde</label>

--- a/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
+++ b/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
@@ -113,7 +113,7 @@ templ EditQuiz(quiz *quizzes.Quiz, articles *[]articles.Article) {
 	}
 	<dialog
 		id="question-modal"
-		class="px-10 py-5 border border-black border-solid min-w-80"
+		class="px-10 py-5 border border-black border-solid min-w-80 max-w-screen-md w-3/4 lg:w-1/2"
 	></dialog>
 	@modalWindowScript()
 }

--- a/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
+++ b/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
@@ -84,13 +84,21 @@ templ EditQuiz(quiz *quizzes.Quiz, articles *[]articles.Article) {
 				<h2>Spørsmål</h2>
 				// List of all questions
 				<ul id="question-list" class="w-full bg-gray-300 [&>*:nth-child(odd)]:bg-gray-200">
-					if len(quiz.Questions) == 0 {
-						<li class="text-center px-2 py-4">Ingen spørsmål lagt til enda.</li>
-					}
+					<li
+						id="no-questions-warning"
+						if len(quiz.Questions) == 0 {
+							class="text-center px-2 py-4"
+						} else {
+							class="text-center px-2 py-4 hidden"
+						}
+					>
+						<p>Ingen spørsmål lagt til enda.</p>
+					</li>
 					for _, question := range quiz.Questions {
 						@dashboard_components.QuestionListItem(&question)
 					}
 				</ul>
+				@questionList()
 				<button hx-get={ fmt.Sprintf("/dashboard/edit-quiz/new-question?quiz-id=%s", quiz.ID) } hx-swap="innerHTML" hx-target="#question-modal" hx-trigger="click" type="button" id="new-question-button" class="mt-3 px-3 py-1 bg-gray-300 block mx-auto">Legg til nytt spørsmål ➕</button>
 				// <button type="button" id="new-question-button" class="mt-3 px-3 py-1 bg-gray-300 block mx-auto">Legg til nytt spørsmål ➕</button>
 			}
@@ -141,7 +149,7 @@ script modalWindowScript() {
 }
 
 // This script is used to observe changes in the article list.
-// If the warning is displayed and  an article is added, hide the warning.
+// If the warning is displayed and an article is added, hide the warning.
 // If the last article is removed, the warning should be shown.
 
 script articleList() {
@@ -169,6 +177,39 @@ script articleList() {
 				noArticlesWarning.classList.add("hidden");
 			} else if (noArticlesWarning) {
 				noArticlesWarning.classList.remove("hidden");
+			}
+		}
+}
+
+// This script is used to observe changes in the question list.
+// If the warning is displayed and a question is added, hide the warning.
+// If the last question is removed, the warning should be shown.
+
+script questionList() {
+		const questionList = document.getElementById("question-list");
+		const noQuestionsWarning = document.getElementById("no-questions-warning");
+
+		// Observe if the children of question list are mutated (added or removed)
+		const observer = new MutationObserver(handleChanges);
+		const config = { childList: true };
+		observer.observe(questionList, config);
+
+		// If the question list is changed, this function is called
+		function handleChanges(mutationsList, observer) {
+				mutationsList.forEach(mutation => {
+						if (mutation.type === 'childList') {
+								updateWarningVisibility();
+						}
+				});
+		}
+
+		// Update if the warning should be shown or not
+		const updateWarningVisibility = () => {
+			// If the warning is shown, but a question is appended, hide the warning
+			if (noQuestionsWarning && questionList.children.length > 1) {
+				noQuestionsWarning.classList.add("hidden");
+			} else if (noQuestionsWarning) {
+				noQuestionsWarning.classList.remove("hidden");
 			}
 		}
 }

--- a/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
+++ b/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
@@ -10,7 +10,7 @@ import (
 	"github.com/Molnes/Nyhetsjeger/internal/models/quizzes"
 )
 
-// Constants for the input names (for HTTP POST requests)
+// Constants for the input names (for HTTP requests)
 const QuizTitle = "quiz-title"
 const QuizImageURL = "quiz-image-url"
 const QuizPublished = "quiz-is-published"
@@ -41,7 +41,7 @@ templ EditQuiz(quiz *quizzes.Quiz, articles *[]articles.Article) {
 				</div>
 				// TODO: Also support uploading an image
 				// <input id="quiz-image" type="file" accept="image/png, image/jpg, image/jpeg, image/webp" class="bg-gray-100 p-3 w-full [&:hover]:cursor-pointer mb-2"/>
-				@dashboard_components.EditImageInput(&quiz.ImageURL, quiz.ID.String(), QuizImageURL)
+				@dashboard_components.EditImageInput(fmt.Sprintf("/api/v1/admin/quiz/edit-image?quiz-id=%s", quiz.ID), &quiz.ImageURL, QuizImageURL, true)
 			}
 			// Quiz Articles
 			@dashboard_components.EditQuizForm(fmt.Sprintf("/api/v1/admin/quiz/add-article?quiz-id=%s", quiz.ID)) {
@@ -83,7 +83,7 @@ templ EditQuiz(quiz *quizzes.Quiz, articles *[]articles.Article) {
 			@dashboard_components.EditQuizForm("") {
 				<h2>Spørsmål</h2>
 				// List of all questions
-				<ul class="w-full bg-gray-300 [&>*:nth-child(odd)]:bg-gray-200">
+				<ul id="question-list" class="w-full bg-gray-300 [&>*:nth-child(odd)]:bg-gray-200">
 					if len(quiz.Questions) == 0 {
 						<li class="text-center px-2 py-4">Ingen spørsmål lagt til enda.</li>
 					}
@@ -97,7 +97,7 @@ templ EditQuiz(quiz *quizzes.Quiz, articles *[]articles.Article) {
 			@components.LoadingIndicator()
 			// Quiz Buttons: Delete, Hide, OK
 			@dashboard_components.EditQuizForm("") {
-				<div class="flex flex-row justify-around w-full px-5">
+				<div class="flex flex-row flex-wrap justify-around w-full px-5 gap-3">
 					<button
 						class="bg-gray-100 text-red-600 font-bold px-3 py-2 w-40"
 						hx-delete={ fmt.Sprintf("/api/v1/admin/quiz/delete-quiz?quiz-id=%s", quiz.ID) }


### PR DESCRIPTION
Create a question and add to quiz. Works whether the article already exists in the DB or not, whether the quiz has the article or not, but does not update the article list UI. The HTMX response only returns the newly created question. TODO: Find a fix for this.

Hardcoded in 4 answer alternatives, and just removes any empty ones from being added to the database. Checks if 2 to 4 alternatives are filled in. Potentially dynamically create inputs for alternatives in the future, but for MVP this works as expected.