### PR TITLE
feat: add simple redirect to quiz page

### DIFF
--- a/internal/web_server/web/views/pages/quiz_pages/quiz_summary_page.templ
+++ b/internal/web_server/web/views/pages/quiz_pages/quiz_summary_page.templ
@@ -33,7 +33,7 @@ templ QuizSummaryPage(summary *user_quiz_summary.UserQuizSummary) {
 					}
 				</ol>
 			</section>
-			<button class="bg-gray-200 text-blackd px-10 py-1 font-bold">NESTE</button>
+			<button class="bg-gray-200 text-blackd px-10 py-1 font-bold" onclick="window.location.href = '/quiz'">NESTE</button>
 		</div>
 	}
 }


### PR DESCRIPTION
Currently when being on the results page, the "neste" button does nothing, added a simple redirect to the starting quiz page