### PR TITLE
Style/summary articles

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -60,7 +60,8 @@
     bottom: 0;
 }
 
-.gradient-shadow {
+.gradient-shadow,
+.gradient-shadow-always {
     position: relative;
 }
 

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -120,3 +120,7 @@
 .tooltip-parent:hover>.tooltip {
     display: inline-block;
 }
+
+.gradient-bg-button {
+    @apply text-white font-sans rounded-button bg-center text-center cgradient font-bold;
+}

--- a/internal/web_server/web/handlers/quiz_pages_handlers.go
+++ b/internal/web_server/web/handlers/quiz_pages_handlers.go
@@ -19,8 +19,8 @@ import (
 
 const (
 	errInvalidOrMissingQuizID    = "Manglende eller ugyldig quiz-id"
-	errNoSuchQuiz                = "Quizzen ble ikke funnet"
-	errQuizNotCompletedNoSummary = "Quizzen er ikke fullført, oppsummering er ikke tilgjengelig"
+	errNoSuchQuiz                = "Quizen ble ikke funnet"
+	errQuizNotCompletedNoSummary = "Quizen er ikke fullført, oppsummering er ikke tilgjengelig"
 )
 
 type QuizPagesHandler struct {
@@ -53,11 +53,10 @@ func (qph *QuizPagesHandler) quizHomePage(c echo.Context) error {
 		return err
 	}
 
-    oldQuizzes, err := quizzes.GetQuizzesByUserIDAndFinishedOrNotAndNotActive(qph.sharedData.DB, utils.GetUserIDFromCtx(c), false)
-        if err != nil {
-                return err
-        }
-
+	oldQuizzes, err := quizzes.GetQuizzesByUserIDAndFinishedOrNotAndNotActive(qph.sharedData.DB, utils.GetUserIDFromCtx(c), false)
+	if err != nil {
+		return err
+	}
 
 	userRankingInfo := user_ranking.UserRanking{}
 
@@ -80,7 +79,7 @@ func (qph *QuizPagesHandler) quizHomePage(c echo.Context) error {
 	}
 	return utils.Render(c, http.StatusOK, quiz_pages.QuizHomePage(
 		quizList,
-        oldQuizzes,
+		oldQuizzes,
 		userRankingInfo,
 	))
 }

--- a/internal/web_server/web/views/components/quiz_components/article_card.templ
+++ b/internal/web_server/web/views/components/quiz_components/article_card.templ
@@ -9,12 +9,12 @@ import (
 templ ArticleCard(article *articles.Article) {
 	<a
 		href={ templ.SafeURL(article.ArticleURL.String()) }
-		class="gradient-shadow-always w-fit h-fit"
+		class="w-fit h-fit"
 		target="_blank"
 	>
-		<article class="flex flex-row items-center bg-white max-w-screen-md aspect-[5/1] rounded-card overflow-hidden">
-			<img src={ article.ImgURL.String() } height="120" width="120" class="object-cover rounded-l-card h-full w-auto aspect-square"/>
-			<p class="font-bold text-center px-4 py-2 mx-auto text-xl leading-snug">{ article.Title }</p>
+		<article class="flex flex-row items-center bg-white max-w-screen-md rounded-card overflow-hidden border-2 border-cindigo">
+			<img src={ article.ImgURL.String() } height="120" width="120" class="hidden md:block object-cover rounded-l-card w-1/5 aspect-square"/>
+			<p class="font-bold text-center px-6 py-4 mx-auto md:text-xl leading-snug">{ article.Title }</p>
 		</article>
 	</a>
 }

--- a/internal/web_server/web/views/components/quiz_components/article_list.templ
+++ b/internal/web_server/web/views/components/quiz_components/article_list.templ
@@ -10,7 +10,7 @@ templ ArticleList(articles *[]articles.Article) {
 		class="flex flex-col justify-start items-center gap-5 px-1 py-5 isolate"
 	>
 		<h1 class="font-bold text-3xl">Artikler</h1>
-		<p class="text-center text-lg">
+		<p class="text-center text-lg text-balance">
 			Dette er sakene som spørsmålene var basert på. Klikk på en sak for å lese artikkelen!
 			<span class="block text-center text-gray-700 text-sm mt-3">(Dette vil åpne en ny fane)</span>
 		</p>

--- a/internal/web_server/web/views/components/quiz_components/article_list.templ
+++ b/internal/web_server/web/views/components/quiz_components/article_list.templ
@@ -16,7 +16,7 @@ templ ArticleList(articles *[]articles.Article) {
 				<li><p class="text-center">Ingen artikler å vise</p></li>
 			} else {
 				for _, article := range *articles {
-					<li class="relative isolate">
+					<li>
 						@ArticleCard(&article)
 					</li>
 				}

--- a/internal/web_server/web/views/components/quiz_components/article_list.templ
+++ b/internal/web_server/web/views/components/quiz_components/article_list.templ
@@ -10,7 +10,11 @@ templ ArticleList(articles *[]articles.Article) {
 		class="flex flex-col justify-start items-center gap-5 px-1 py-5 isolate"
 	>
 		<h1 class="font-bold text-3xl">Artikler</h1>
-		<p class="text-center text-lg">Sjekk ut artiklene som spørsmålene var basert på!</p>
+		<p class="text-center text-lg">
+			Dette er sakene som spørsmålene var basert på. Klikk på en sak for å lese artikkelen!
+			<br/>
+			<span class="text-center text-gray-700 text-sm">(Merk at dette vil åpne en ny fane.)</span>
+		</p>
 		<ul class="flex flex-col p-6 gap-10 overflow-y-auto scrollbar-hide grow">
 			if len(*articles) == 0 {
 				<li><p class="text-center">Ingen artikler å vise</p></li>
@@ -23,7 +27,7 @@ templ ArticleList(articles *[]articles.Article) {
 			}
 		</ul>
 		<a
-			class="text-xl py-2 px-8 w-min rounded-button bg-white gradient-outline gradient-shadow text-wrap"
+			class="gradient-bg-button py-3 px-8 text-xl"
 			href={ templ.SafeURL("/quiz") }
 		>
 			Ferdig

--- a/internal/web_server/web/views/components/quiz_components/article_list.templ
+++ b/internal/web_server/web/views/components/quiz_components/article_list.templ
@@ -12,10 +12,9 @@ templ ArticleList(articles *[]articles.Article) {
 		<h1 class="font-bold text-3xl">Artikler</h1>
 		<p class="text-center text-lg">
 			Dette er sakene som spørsmålene var basert på. Klikk på en sak for å lese artikkelen!
-			<br/>
-			<span class="text-center text-gray-700 text-sm">(Merk at dette vil åpne en ny fane.)</span>
+			<span class="block text-center text-gray-700 text-sm mt-3">(Dette vil åpne en ny fane)</span>
 		</p>
-		<ul class="flex flex-col p-6 gap-10 overflow-y-auto scrollbar-hide grow">
+		<ul class="flex flex-col p-6 gap-6 overflow-y-auto scrollbar-hide grow">
 			if len(*articles) == 0 {
 				<li><p class="text-center">Ingen artikler å vise</p></li>
 			} else {

--- a/internal/web_server/web/views/components/quiz_components/quiz_card.templ
+++ b/internal/web_server/web/views/components/quiz_components/quiz_card.templ
@@ -15,7 +15,7 @@ templ QuizCard(quiz quizzes.Quiz) {
 		<div class="bg-white mt-0 grid grid-cols-1 gap-4 rounded-b-card">
 			<h3 class="px-2 text-2xl mt-6 mx-auto text-center font-semibold text-gray-800 text-ellipsis overflow-hidden whitespace-nowrap">{ quiz.Title }</h3>
 			<a
-				class="text-white font-sans py-2 px-10 mx-auto mb-6 rounded-button bg-center text-center cgradient font-bold"
+				class="gradient-bg-button py-2 px-10 mx-auto mb-6"
 				href={ templ.SafeURL("/quiz/play?quiz-id=" + quiz.ID.String()) }
 			>
 				SPILL

--- a/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
+++ b/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
@@ -49,7 +49,7 @@ templ EditQuiz(quiz *quizzes.Quiz, articles *[]articles.Article, questions *[]qu
 			// Quiz Articles
 			@dashboard_components.EditQuizForm(fmt.Sprintf("/api/v1/admin/quiz/add-article?quiz-id=%s", quiz.ID)) {
 				<div class="flex flex-row items-center gap-3 mb-1">
-					<h2 class="font-bold">Artikler i quizzen</h2>
+					<h2 class="font-bold">Artikler i quizen</h2>
 					@components.LoadingIndicator()
 				</div>
 				@dashboard_components.AddArticleInput(quiz.ID.String(), QuizArticleURL, "")
@@ -137,7 +137,7 @@ templ EditQuiz(quiz *quizzes.Quiz, articles *[]articles.Article, questions *[]qu
 						hx-target-4*=".error-quiz"
 						hx-sync="closest form:abort"
 						hx-indicator="previous .htmx-indicator"
-						hx-confirm="Er du sikker på at du ønsker å slette denne quizzen?"
+						hx-confirm="Er du sikker på at du ønsker å slette denne quizen?"
 					>Slett quiz</button>
 					@dashboard_components.ToggleQuizPublished(quiz.Published, quiz.ID.String(), QuizPublished)
 					<a href="/dashboard" class="bg-clightindigo font-bold px-4 py-2 text-center rounded-button">Ferdig</a>

--- a/internal/web_server/web/views/pages/public_pages/home_page.templ
+++ b/internal/web_server/web/views/pages/public_pages/home_page.templ
@@ -4,11 +4,11 @@ import "github.com/Molnes/Nyhetsjeger/internal/web_server/web/views/components/l
 
 templ HomePage() {
 	@layout_components.BaseLayout("Nyhetsjeger") {
-		<main class="flex flex-col items-center justify-center min-h-screen">
-			<h1>QUIZ</h1>
-			<p>Velkomen til nyhetsjeger</p>
+		<main class="flex flex-col gap-5 items-center justify-center min-h-screen">
+			<h1 class="text-2xl">QUIZ</h1>
+			<p>Velkomen til Nyhetsjeger</p>
 			<a
-				class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-button"
+				class="gradient-bg-button py-2 px-4"
 				href="/login"
 			>SPILL NÅ</a>
 		</main>

--- a/internal/web_server/web/views/pages/public_pages/login_page.templ
+++ b/internal/web_server/web/views/pages/public_pages/login_page.templ
@@ -4,16 +4,16 @@ import "github.com/Molnes/Nyhetsjeger/internal/web_server/web/views/components/l
 
 templ LoginPage() {
 	@layout_components.BaseLayout("Logg inn") {
-		<div class="flex flex-col items-center justify-center min-h-screen">
+		<div class="flex flex-col gap-3 items-center justify-center min-h-screen">
 			<a
 				href="/auth/google/login"
-				class="bg-blue-500 hover:bg-blue-700 text-white font-bold py-2 px-4 rounded-button"
+				class="gradient-bg-button py-2 px-4"
 			>
 				Logg inn med Google
 			</a>
 			<a
 				href="/"
-				class="text-blue-500 hover:underline mt-3"
+				class="text-gray-700 hover:underline"
 			>Fortsett som gjest</a>
 		</div>
 	}

--- a/internal/web_server/web/views/pages/quiz_pages/quiz_home_page.templ
+++ b/internal/web_server/web/views/pages/quiz_pages/quiz_home_page.templ
@@ -33,8 +33,8 @@ templ QuizHomePage(quizzes []quizzes.Quiz, olderQuizzes []quizzes.Quiz, userInfo
 				<h2 class="text-4xl p-4">Aktive quizer</h2>
 				<div class="flex flex-row justify-center md:justify-start flex-wrap p-4 lg:gap-20 gap-10">
 					if len(quizzes) == 0 {
-						<p class="text-xl w-full p-5 border border-clightindigo rounded-card bg-violet-100 text-center">
-							Beklager, ingen quizer tilgjengelig for øyeblikket. Kom tilbake senere!
+						<p class="text-balance w-full p-5 border border-clightindigo rounded-card bg-violet-100 text-center">
+							Wow, du har fullført alle aktive quizer! Du er rå! Kom tilbake senere.
 						</p>
 					}
 					for _, quiz := range quizzes {
@@ -46,8 +46,8 @@ templ QuizHomePage(quizzes []quizzes.Quiz, olderQuizzes []quizzes.Quiz, userInfo
 				<h2 class="text-4xl p-4">Tidligere quizer</h2>
 				<div class="flex flex-row justify-center md:justify-start flex-wrap p-4 lg:gap-20 gap-10">
 					if len(olderQuizzes) == 0 {
-						<p class="text-xl w-full p-5 border border-clightindigo rounded-card bg-violet-100 text-center">
-							Beklager, ingen tidligere quizer tilgjengelig for øyeblikket. Kom tilbake senere!
+						<p class="text-balance w-full p-5 border border-clightindigo rounded-card bg-violet-100 text-center">
+							Wow, du har fullført alle tidligere quizer! Kom tilbake senere.
 						</p>
 					}
 					for _, quiz := range olderQuizzes {

--- a/internal/web_server/web/views/pages/quiz_pages/quiz_summary_page.templ
+++ b/internal/web_server/web/views/pages/quiz_pages/quiz_summary_page.templ
@@ -14,7 +14,7 @@ templ QuizSummaryPage(summary *user_quiz_summary.UserQuizSummary) {
 	@layout_components.QuizLayout("Oppsummering") {
 		<div
 			id="quiz-summary"
-			class="flex flex-col gap-10 justify-start items-center p-5 h-dvh isolate"
+			class="flex flex-col gap-8 justify-start items-center p-5 isolate"
 		>
 			<section class="flex flex-col gap-3 items-center">
 				<h1 class="text-3xl">Resultat</h1>
@@ -36,10 +36,10 @@ templ QuizSummaryPage(summary *user_quiz_summary.UserQuizSummary) {
 					</p>
 				</div>
 			</section>
-			<section class="flex flex-col gap-4 items-center scrollbar-hide w-full">
+			<section class="flex flex-col gap-4 items-center scrollbar-hide">
 				<h2 class="text-2xl">Oppsummering</h2>
 				<div class="gradient-outline w-fit h-fit">
-					<ol class="list-decimal pl-8 pr-4 py-4 space-y-4 max-h-[calc(100dvh-22em)] min-w-80 max-w-full overflow-y-auto scrollbar-hide bg-white rounded-card">
+					<ol class="list-decimal pl-8 pr-4 py-4 space-y-4 max-h-[calc(100dvh-24rem)] min-w-80 max-w-full overflow-y-auto scrollbar-hide bg-white rounded-card">
 						for _, aq := range summary.AnsweredQuestions {
 							@chosenAnswer(aq)
 						}


### PR DESCRIPTION
- Fix summary overflowing on summary page
- Fix articles overflow hidden issue on shorter screens; making it impossible to read the article title
- Style article cards to look more professional
- Gradient background on "Neste" button
- Update text describing articles to make it clear how to open an article and that it opens to an external page