### PR TITLE
Feat/nicer dragndrop images

### DIFF
--- a/internal/web_server/web/handlers/api/admin_api.go
+++ b/internal/web_server/web/handlers/api/admin_api.go
@@ -159,7 +159,7 @@ func (aah *AdminApiHandler) editQuizImage(c echo.Context) error {
 	}
 
 	return utils.Render(c, http.StatusOK, dashboard_components.EditImageInput(
-		fmt.Sprintf(editQuizImageURL, quiz_id), fmt.Sprintf(editQuizImageFile, quiz_id), imageURL, true, ""))
+		fmt.Sprintf(editQuizImageURL, quiz_id), fmt.Sprintf(editQuizImageFile, quiz_id), imageURL, true, "", dashboard_components.IdPrefixQuiz))
 }
 
 func (aah *AdminApiHandler) uploadQuizImage(c echo.Context) error {
@@ -201,7 +201,7 @@ func (aah *AdminApiHandler) uploadQuizImage(c echo.Context) error {
 	}
 
 	return utils.Render(c, http.StatusOK, dashboard_components.EditImageInput(
-		fmt.Sprintf(editQuizImageURL, quiz_id), fmt.Sprintf(editQuizImageFile, quiz_id), imageAsURL, true, ""))
+		fmt.Sprintf(editQuizImageURL, quiz_id), fmt.Sprintf(editQuizImageFile, quiz_id), imageAsURL, true, "", dashboard_components.IdPrefixQuiz))
 }
 
 // Removes the image for a quiz in the database.
@@ -219,7 +219,7 @@ func (dph *AdminApiHandler) deleteQuizImage(c echo.Context) error {
 	}
 
 	return utils.Render(c, http.StatusOK, dashboard_components.EditImageInput(
-		fmt.Sprintf(editQuizImageURL, quiz_id), fmt.Sprintf(editQuizImageFile, quiz_id), &url.URL{}, true, ""))
+		fmt.Sprintf(editQuizImageURL, quiz_id), fmt.Sprintf(editQuizImageFile, quiz_id), &url.URL{}, true, "", dashboard_components.IdPrefixQuiz))
 }
 
 // Deletes a quiz from the database.
@@ -692,7 +692,7 @@ func (aah *AdminApiHandler) editQuestionImage(c echo.Context) error {
 	}
 
 	return utils.Render(c, http.StatusOK, dashboard_components.EditImageInput(
-		fmt.Sprintf(editQuestionImageURL, questionID), fmt.Sprintf(editQuestionImageFile, questionID), imageURL, true, ""))
+		fmt.Sprintf(editQuestionImageURL, questionID), fmt.Sprintf(editQuestionImageFile, questionID), imageURL, true, "", dashboard_components.IdPrefixQuestion))
 }
 
 // Upload a new image for a question.
@@ -735,7 +735,7 @@ func (aah *AdminApiHandler) uploadQuestionImage(c echo.Context) error {
 	}
 
 	return utils.Render(c, http.StatusOK, dashboard_components.EditImageInput(
-		fmt.Sprintf(editQuestionImageURL, questionID), fmt.Sprintf(editQuestionImageFile, questionID), imageAsURL, true, ""))
+		fmt.Sprintf(editQuestionImageURL, questionID), fmt.Sprintf(editQuestionImageFile, questionID), imageAsURL, true, "", dashboard_components.IdPrefixQuestion))
 }
 
 // Delete the image for a question in the database.
@@ -744,7 +744,7 @@ func (aah *AdminApiHandler) deleteQuestionImage(c echo.Context) error {
 	questionID, err := uuid.Parse(c.QueryParam(queryParamQuestionID))
 	if err != nil {
 		return utils.Render(c, http.StatusOK, dashboard_components.EditImageInput(
-			fmt.Sprintf(editQuestionImageURL, questionID), fmt.Sprintf(editQuestionImageFile, questionID), &url.URL{}, true, errorInvalidQuestionID))
+			fmt.Sprintf(editQuestionImageURL, questionID), fmt.Sprintf(editQuestionImageFile, questionID), &url.URL{}, true, errorInvalidQuestionID, dashboard_components.IdPrefixQuestion))
 	}
 
 	// Remove the image URL from the question
@@ -752,14 +752,14 @@ func (aah *AdminApiHandler) deleteQuestionImage(c echo.Context) error {
 	if err != nil {
 		if err == questions.ErrNoImageRemoved {
 			return utils.Render(c, http.StatusOK, dashboard_components.EditImageInput(
-				fmt.Sprintf(editQuestionImageURL, questionID), fmt.Sprintf(editQuestionImageFile, questionID), &url.URL{}, true, "Spørsmål bilde kunne ikke bli fjernet. Prøv igjen senere"))
+				fmt.Sprintf(editQuestionImageURL, questionID), fmt.Sprintf(editQuestionImageFile, questionID), &url.URL{}, true, "Spørsmål bilde kunne ikke bli fjernet. Prøv igjen senere", dashboard_components.IdPrefixQuestion))
 		}
 
 		return err
 	}
 
 	return utils.Render(c, http.StatusOK, dashboard_components.EditImageInput(
-		fmt.Sprintf(editQuestionImageURL, questionID), fmt.Sprintf(editQuestionImageFile, questionID), &url.URL{}, true, ""))
+		fmt.Sprintf(editQuestionImageURL, questionID), fmt.Sprintf(editQuestionImageFile, questionID), &url.URL{}, true, "", dashboard_components.IdPrefixQuestion))
 }
 
 // Uploads an image to the bucket from a form and returns the name of the image.

--- a/internal/web_server/web/handlers/api/admin_api.go
+++ b/internal/web_server/web/handlers/api/admin_api.go
@@ -543,14 +543,19 @@ func (aah *AdminApiHandler) editQuestion(c echo.Context) error {
 		alternatives[index] = questions.PartialAlternative{Text: alternativeText, IsCorrect: isCorrect == "on"}
 	}
 
+	var hasFile = true
 	// Get the image file if it exists and upload it
-	if c.FormValue(imageFileInput) != "" {
-		imageFile, err := c.FormFile(imageFileInput)
-		if err != nil {
+	imageFile, err := c.FormFile(imageFileInput)
+	if err != nil {
+		if err == http.ErrMissingFile {
+			hasFile = false
+		} else {
 			log.Println(err)
 			return utils.Render(c, http.StatusBadRequest, components.ErrorText(errorQuestionElementID, errorFetchingImage))
 		}
+	}
 
+	if hasFile {
 		// Upload image from File
 		imageName, err := aah.uploadImage(c, imageFile)
 		if err != nil {

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
@@ -185,53 +185,58 @@ script switchTabs() {
 script indicateDragAndDrop(inputId string, dropzoneId string, fileNameId string) {
 	const dropZone = document.getElementById(dropzoneId);
 
-	['dragenter','dragover'].forEach(eventName => {
+	["dragenter", "dragover"].forEach((eventName) => {
 		document.body.addEventListener(eventName, (evt) => {
-			if (!evt.target.classList.contains('drag-handle') && evt.dataTransfer.types.includes('Files')){
-				dropZone.classList.remove('hidden');
-			
+			if (
+				!evt.target.classList.contains("drag-handle") &&
+				evt.dataTransfer.types.includes("Files")
+			) {
+				dropZone.classList.remove("hidden");
+
 				evt.preventDefault();
 
 				if (evt.srcElement.id == dropzoneId) {
-					evt.dataTransfer.dropEffect = 'copy';
+					evt.dataTransfer.dropEffect = "copy";
 				} else {
-					evt.dataTransfer.dropEffect = 'none';
+					evt.dataTransfer.dropEffect = "none";
 				}
 			}
 		});
 	});
 
-
 	const inputField = document.getElementById(inputId);
 	const fileNameDisplay = document.getElementById(fileNameId);
-	['dragleave','drop'].forEach(eventName => {
+	["dragleave", "drop"].forEach((eventName) => {
 		document.body.addEventListener(eventName, (evt) => {
-			dropZone.classList.add('hidden');
+			dropZone.classList.add("hidden");
 
 			evt.preventDefault();
 
-			if (evt.name='drop'
-			&& evt.dataTransfer.files.length == 1
-			&& evt.srcElement.id == dropzoneId){
-				inputField.files =  evt.dataTransfer.files;
-				inputField.dispatchEvent(new Event('change'));
+			if (
+				(evt.name =
+					"drop" &&
+					evt.dataTransfer.files.length == 1 &&
+					evt.srcElement.id == dropzoneId)
+			) {
+				inputField.files = evt.dataTransfer.files;
+				inputField.dispatchEvent(new Event("change"));
 			}
 		});
 	});
 
 	// if file changes (either chosen with file chooser or drag-and-dropped)
-	inputField.addEventListener('change', (evt) => {
+	inputField.addEventListener("change", (evt) => {
 		const files = evt.target.files;
-		console.log('change detected');
 		if (files.length > 0) {
-			fileNameDisplay.innerText= files[0].name;
+			fileNameDisplay.innerText = files[0].name;
 		}
 	});
 
 	// set the file name display if there is a file selected already (may happen after refresh)
 	if (inputField.files.length > 0) {
-		fileNameDisplay.innerText= inputField.files[0].name;
+		fileNameDisplay.innerText = inputField.files[0].name;
 	}
+
 }
 
 script openFileChooser(fileInputId string) {

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
@@ -172,7 +172,7 @@ script indicateDragAndDrop(inputId string, dropzoneId string, fileNameId string)
 	const imageFileTab = document.getElementById('image-file-input');
 	['dragenter','dragover'].forEach(eventName => {
 		document.body.addEventListener(eventName, (evt) => {
-			if (!imageFileTab.classList.contains('hidden')){
+			if (!imageFileTab.classList.contains('hidden') && !evt.target.classList.contains('drag-handle')){
 				dropZone.classList.remove('hidden');
 			
 				evt.preventDefault();

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
@@ -56,19 +56,23 @@ templ EditImageInput(imageURLEndpoint string, imageFileEndpoint string, imageURL
 				}
 			</div>
 			<div id="image-file-input" class="min-h-12 flex flex-row items-center gap-3 flex-wrap mb-3 hidden relative" data-element-type="tab-content">
-				<label for="image-file" class="flex-grow">Velg en fil</label>
+				<label for="image-file">Velg en fil</label>
 				<input
 					id="image-file"
 					name="image-file"
-					class="bg-purple-100 px-4 py-1 rounded-input border border-clightindigo w-1/2  hidden"
+					hidden
 					type="file"
 					accept="image/png, image/jpeg, image/jpg, image/gif, image/webp"
 				/>
-				<button class="bg-clightindigo px-4 py-2 rounded-button" onclick="event.preventDefault(); document.getElementById('image-file').click();">Eller bla gjennom filene</button>
-				<p id="file-name-display">Ingen fil valgt</p>
+				<div class="flex-grow flex flex-col justify-center items-center bg-purple-50 px-4 py-2 rounded-input border border-clightindigo w-1/2">
+					<p>Dra og slipp</p>
+					<p class="text-gray-700 ">eller</p>
+					<button class="bg-clightindigo px-4 py-2 my-1 rounded-button" onclick="event.preventDefault(); document.getElementById('image-file').click();">Bla gjennom filene</button>
+					<p id="file-name-display" class="text-gray-700">Ingen fil valgt</p>
+				</div>
 				<div
 					id="drop-zone"
-					class="absolute top-0 w-full h-80 border border-cindigo bg-purple-100 bg-opacity-75  flex items-center justify-center text-4xl text-cindigo font-sans hidden"
+					class="absolute top-0 w-full h-full border border-cindigo bg-purple-100 bg-opacity-75  flex items-center justify-center text-4xl text-cindigo font-sans hidden"
 				>
 					Slipp her
 				</div>
@@ -172,7 +176,7 @@ script indicateDragAndDrop(inputId string, dropzoneId string, fileNameId string)
 	const imageFileTab = document.getElementById('image-file-input');
 	['dragenter','dragover'].forEach(eventName => {
 		document.body.addEventListener(eventName, (evt) => {
-			if (!imageFileTab.classList.contains('hidden') && !evt.target.classList.contains('drag-handle')){
+			if (!evt.target.classList.contains('drag-handle') && evt.dataTransfer.types.includes('Files')){
 				dropZone.classList.remove('hidden');
 			
 				evt.preventDefault();
@@ -191,15 +195,13 @@ script indicateDragAndDrop(inputId string, dropzoneId string, fileNameId string)
 	const fileNameDisplay = document.getElementById(fileNameId);
 	['dragleave','drop'].forEach(eventName => {
 		document.body.addEventListener(eventName, (evt) => {
-			if (!imageFileTab.classList.contains('hidden')){
-				dropZone.classList.add('hidden');
+			dropZone.classList.add('hidden');
 
-				evt.preventDefault();
+			evt.preventDefault();
 
-				if (evt.name='drop' && evt.dataTransfer.files.length == 1){
-					inputField.files =  evt.dataTransfer.files;
-					inputField.dispatchEvent(new Event('change'));
-				}
+			if (evt.name='drop' && evt.dataTransfer.files.length == 1){
+				inputField.files =  evt.dataTransfer.files;
+				inputField.dispatchEvent(new Event('change'));
 			}
 		});
 	});

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
@@ -4,13 +4,22 @@ import (
 	"net/url"
 	"github.com/Molnes/Nyhetsjeger/internal/web_server/web/views/components"
 	"github.com/Molnes/Nyhetsjeger/internal/web_server/web/views/components/icons"
+	"github.com/google/uuid"
+	"fmt"
 )
+
+const (
+	IdPrefixQuiz     = "quiz"
+	IdPrefixQuestion = "question"
+)
+
+var randomId uuid.UUID
 
 // An input field for updating the image.
 // When the value is changed, send a POST request to the given URL for updating the image.
 // It will trigger the previous loading indicator to display.
 // If post is set to false, it will not send a request when the value is changed.
-templ EditImageInput(imageURLEndpoint string, imageFileEndpoint string, imageURL *url.URL, post bool, errorText string) {
+templ EditImageInput(imageURLEndpoint string, imageFileEndpoint string, imageURL *url.URL, post bool, errorText string, idPrefix string) {
 	<div class="image-input-wrapper">
 		<div class="flex flex-row bg-violet-50 border border-clightindigo rounded-t-card overflow-hidden">
 			<button
@@ -31,10 +40,10 @@ templ EditImageInput(imageURLEndpoint string, imageFileEndpoint string, imageURL
 			</button>
 		</div>
 		<div class="border-b border-l border-r border-clightindigo rounded-b-card p-4">
-			<div id="image-url-input" class="min-h-12 flex flex-row items-center gap-3 flex-wrap mb-3" data-element-type="tab-content">
-				<label for="image-url">Velg URL</label>
+			<div id="image-url-input-tab" class="min-h-12 flex flex-row items-center gap-3 flex-wrap mb-3" data-element-type="tab-content">
+				<label for={ fmt.Sprintf("%s-image-url-input", idPrefix) }>Velg URL</label>
 				<input
-					id="image-url"
+					id={ fmt.Sprintf("%s-image-url-input", idPrefix) }
 					name="image-url"
 					class="bg-purple-100 px-4 py-2 rounded-input border border-clightindigo w-1/2 flex-grow"
 					type="text"
@@ -55,10 +64,10 @@ templ EditImageInput(imageURLEndpoint string, imageFileEndpoint string, imageURL
 					>Last opp</button>
 				}
 			</div>
-			<div id="image-file-input" class="min-h-12 flex flex-row items-center gap-3 flex-wrap mb-3 hidden relative" data-element-type="tab-content">
-				<label for="image-file">Velg en fil</label>
+			<div id="image-file-input-tab" class="min-h-12 flex flex-row items-center gap-3 flex-wrap mb-3 hidden relative" data-element-type="tab-content">
+				<label for={ fmt.Sprintf("%s-image-file-input", idPrefix) }>Velg en fil</label>
 				<input
-					id="image-file"
+					id={ fmt.Sprintf("%s-image-file-input", idPrefix) }
 					name="image-file"
 					hidden
 					type="file"
@@ -67,16 +76,19 @@ templ EditImageInput(imageURLEndpoint string, imageFileEndpoint string, imageURL
 				<div class="flex-grow flex flex-col justify-center items-center bg-purple-50 px-4 py-2 rounded-input border border-clightindigo w-1/2">
 					<p>Dra og slipp</p>
 					<p class="text-gray-700 ">eller</p>
-					<button class="bg-clightindigo px-4 py-2 my-1 rounded-button" onclick="event.preventDefault(); document.getElementById('image-file').click();">Bla gjennom filene</button>
-					<p id="file-name-display" class="text-gray-700">Ingen fil valgt</p>
+					<button
+						class="bg-clightindigo px-4 py-2 my-1 rounded-button"
+						onclick={ openFileChooser(fmt.Sprintf("%s-image-file-input", idPrefix)) }
+					>Bla gjennom filene</button>
+					<p id={ fmt.Sprintf("%s-file-name-display", idPrefix) } class="text-gray-700">Ingen fil valgt</p>
 				</div>
 				<div
-					id="drop-zone"
+					id={ fmt.Sprintf("%s-file-drop-zone", idPrefix) }
 					class="absolute top-0 w-full h-full border border-cindigo bg-purple-100 bg-opacity-75  flex items-center justify-center text-4xl text-cindigo font-sans hidden"
 				>
 					Slipp her
 				</div>
-				@indicateDragAndDrop("image-file", "drop-zone", "file-name-display")
+				@indicateDragAndDrop(fmt.Sprintf("%s-image-file-input", idPrefix), fmt.Sprintf("%s-file-drop-zone", idPrefix), fmt.Sprintf("%s-file-name-display", idPrefix))
 				if post {
 					<button
 						type="button"
@@ -173,7 +185,6 @@ script switchTabs() {
 script indicateDragAndDrop(inputId string, dropzoneId string, fileNameId string) {
 	const dropZone = document.getElementById(dropzoneId);
 
-	const imageFileTab = document.getElementById('image-file-input');
 	['dragenter','dragover'].forEach(eventName => {
 		document.body.addEventListener(eventName, (evt) => {
 			if (!evt.target.classList.contains('drag-handle') && evt.dataTransfer.types.includes('Files')){
@@ -199,7 +210,9 @@ script indicateDragAndDrop(inputId string, dropzoneId string, fileNameId string)
 
 			evt.preventDefault();
 
-			if (evt.name='drop' && evt.dataTransfer.files.length == 1){
+			if (evt.name='drop'
+			&& evt.dataTransfer.files.length == 1
+			&& evt.srcElement.id == dropzoneId){
 				inputField.files =  evt.dataTransfer.files;
 				inputField.dispatchEvent(new Event('change'));
 			}
@@ -209,6 +222,7 @@ script indicateDragAndDrop(inputId string, dropzoneId string, fileNameId string)
 	// if file changes (either chosen with file chooser or drag-and-dropped)
 	inputField.addEventListener('change', (evt) => {
 		const files = evt.target.files;
+		console.log('change detected');
 		if (files.length > 0) {
 			fileNameDisplay.innerText= files[0].name;
 		}
@@ -218,4 +232,9 @@ script indicateDragAndDrop(inputId string, dropzoneId string, fileNameId string)
 	if (inputField.files.length > 0) {
 		fileNameDisplay.innerText= inputField.files[0].name;
 	}
+}
+
+script openFileChooser(fileInputId string) {
+	event.preventDefault();
+	document.getElementById(fileInputId).click();
 }

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
@@ -64,6 +64,7 @@ templ EditImageInput(imageURLEndpoint string, imageFileEndpoint string, imageURL
 					type="file"
 					accept="image/png, image/jpeg, image/jpg, image/gif, image/webp"
 				/>
+				@indicateDragAndDrop("image-file")
 				if post {
 					<button
 						type="button"
@@ -155,4 +156,14 @@ script switchTabs() {
 		}
 	}
 	imageWrapper.addEventListener("htmx:afterSwap", switchListener);
+}
+
+script indicateDragAndDrop(inputId string) {
+	const inputField = document.getElementById(inputId);
+	inputField.addEventListener("dragenter", (evt) => {
+		console.log("enter")
+	});
+	inputField.addEventListener("dragleave", (evt) => {
+		console.log("leave")
+	});
 }

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
@@ -55,16 +55,24 @@ templ EditImageInput(imageURLEndpoint string, imageFileEndpoint string, imageURL
 					>Last opp</button>
 				}
 			</div>
-			<div id="image-file-input" class="min-h-12 flex flex-row items-center gap-3 flex-wrap mb-3 hidden" data-element-type="tab-content">
-				<label for="image-file">Velg fil</label>
+			<div id="image-file-input" class="min-h-12 flex flex-row items-center gap-3 flex-wrap mb-3 hidden relative" data-element-type="tab-content">
+				<label for="image-file" class="flex-grow">Velg en fil</label>
 				<input
 					id="image-file"
 					name="image-file"
-					class="bg-purple-100 px-4 py-1 rounded-input border border-clightindigo w-1/2 flex-grow"
+					class="bg-purple-100 px-4 py-1 rounded-input border border-clightindigo w-1/2  hidden"
 					type="file"
 					accept="image/png, image/jpeg, image/jpg, image/gif, image/webp"
 				/>
-				@indicateDragAndDrop("image-file")
+				<button class="bg-clightindigo px-4 py-2 rounded-button" onclick="event.preventDefault(); document.getElementById('image-file').click();">Eller bla gjennom filene</button>
+				<p id="file-name-display">Ingen fil valgt</p>
+				<div
+					id="drop-zone"
+					class="absolute top-0 w-full h-80 border border-cindigo bg-purple-100 bg-opacity-75  flex items-center justify-center text-4xl text-cindigo font-sans hidden"
+				>
+					Slipp her
+				</div>
+				@indicateDragAndDrop("image-file", "drop-zone", "file-name-display")
 				if post {
 					<button
 						type="button"
@@ -158,12 +166,54 @@ script switchTabs() {
 	imageWrapper.addEventListener("htmx:afterSwap", switchListener);
 }
 
-script indicateDragAndDrop(inputId string) {
+script indicateDragAndDrop(inputId string, dropzoneId string, fileNameId string) {
+	const dropZone = document.getElementById(dropzoneId);
+
+	const imageFileTab = document.getElementById('image-file-input');
+	['dragenter','dragover'].forEach(eventName => {
+		document.body.addEventListener(eventName, (evt) => {
+			if (!imageFileTab.classList.contains('hidden')){
+				dropZone.classList.remove('hidden');
+			
+				evt.preventDefault();
+
+				if (evt.srcElement.id == dropzoneId) {
+					evt.dataTransfer.dropEffect = 'copy';
+				} else {
+					evt.dataTransfer.dropEffect = 'none';
+				}
+			}
+		});
+	});
+
+
 	const inputField = document.getElementById(inputId);
-	inputField.addEventListener("dragenter", (evt) => {
-		console.log("enter")
+	const fileNameDisplay = document.getElementById(fileNameId);
+	['dragleave','drop'].forEach(eventName => {
+		document.body.addEventListener(eventName, (evt) => {
+			if (!imageFileTab.classList.contains('hidden')){
+				dropZone.classList.add('hidden');
+
+				evt.preventDefault();
+
+				if (evt.name='drop' && evt.dataTransfer.files.length == 1){
+					inputField.files =  evt.dataTransfer.files;
+					inputField.dispatchEvent(new Event('change'));
+				}
+			}
+		});
 	});
-	inputField.addEventListener("dragleave", (evt) => {
-		console.log("leave")
+
+	// if file changes (either chosen with file chooser or drag-and-dropped)
+	inputField.addEventListener('change', (evt) => {
+		const files = evt.target.files;
+		if (files.length > 0) {
+			fileNameDisplay.innerText= files[0].name;
+		}
 	});
+
+	// set the file name display if there is a file selected already (may happen after refresh)
+	if (inputField.files.length > 0) {
+		fileNameDisplay.innerText= inputField.files[0].name;
+	}
 }

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_image_input.templ
@@ -64,8 +64,7 @@ templ EditImageInput(imageURLEndpoint string, imageFileEndpoint string, imageURL
 					>Last opp</button>
 				}
 			</div>
-			<div id="image-file-input-tab" class="min-h-12 flex flex-row items-center gap-3 flex-wrap mb-3 hidden relative" data-element-type="tab-content">
-				<label for={ fmt.Sprintf("%s-image-file-input", idPrefix) }>Velg en fil</label>
+			<div id="image-file-input-tab" class="min-h-12 flex flex-row items-center gap-3 mb-3 hidden relative" data-element-type="tab-content">
 				<input
 					id={ fmt.Sprintf("%s-image-file-input", idPrefix) }
 					name="image-file"
@@ -73,14 +72,17 @@ templ EditImageInput(imageURLEndpoint string, imageFileEndpoint string, imageURL
 					type="file"
 					accept="image/png, image/jpeg, image/jpg, image/gif, image/webp"
 				/>
-				<div class="flex-grow flex flex-col justify-center items-center bg-purple-50 px-4 py-2 rounded-input border border-clightindigo w-1/2">
-					<p>Dra og slipp</p>
-					<p class="text-gray-700 ">eller</p>
-					<button
-						class="bg-clightindigo px-4 py-2 my-1 rounded-button"
-						onclick={ openFileChooser(fmt.Sprintf("%s-image-file-input", idPrefix)) }
-					>Bla gjennom filene</button>
-					<p id={ fmt.Sprintf("%s-file-name-display", idPrefix) } class="text-gray-700">Ingen fil valgt</p>
+				<div class="flex flex-col flex-grow">
+					<label for={ fmt.Sprintf("%s-image-file-input", idPrefix) }>Velg en fil</label>
+					<div class="flex flex-col justify-center items-center bg-purple-50 px-4 py-2 rounded-input border border-clightindigo text-gray-900">
+						@icons.Upload(2, "dimgray", 30, 30)
+						<p>Dra og slipp, eller</p>
+						<button
+							class="underline"
+							onclick={ openFileChooser(fmt.Sprintf("%s-image-file-input", idPrefix)) }
+						>bla gjennom filene dine</button>
+						<p id={ fmt.Sprintf("%s-file-name-display", idPrefix) } class="text-gray-700 mt-2">Ingen fil valgt</p>
+					</div>
 				</div>
 				<div
 					id={ fmt.Sprintf("%s-file-drop-zone", idPrefix) }
@@ -92,7 +94,7 @@ templ EditImageInput(imageURLEndpoint string, imageFileEndpoint string, imageURL
 				if post {
 					<button
 						type="button"
-						class="bg-clightindigo px-4 py-2 rounded-button"
+						class="bg-clightindigo px-4 py-2 rounded-button flex-shrink-0"
 						hx-post={ imageFileEndpoint }
 						hx-trigger="click"
 						hx-swap="outerHTML"

--- a/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_question_form.templ
+++ b/internal/web_server/web/views/components/dashboard_components/edit_quiz/edit_question_form.templ
@@ -78,7 +78,7 @@ templ EditQuestionForm(question questions.Question, articles *[]articles.Article
 			@components.LoadingIndicator()
 		</div>
 		@EditImageInput(fmt.Sprintf("/api/v1/admin/question/edit-image?question-id=%s", question.ID), fmt.Sprintf("/api/v1/admin/question/upload-image?question-id=%s", question.ID),
-			&question.ImageURL, !isNew, "")
+			&question.ImageURL, !isNew, "",IdPrefixQuestion)
 		<div
 			class="relative mt-10 mb-5 text-sm text-gray-500 text-center overflow-hidden
 						before:content-[''] before:absolute before:h-px before:w-1/2 before:bg-gray-400 before:-left-[8ch] before:top-1/2

--- a/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
+++ b/internal/web_server/web/views/pages/dashboard_pages/edit_quiz.templ
@@ -75,7 +75,7 @@ templ EditQuiz(quiz *quizzes.Quiz, articles *[]articles.Article, questions *[]qu
 					@components.LoadingIndicator()
 				</div>
 				@dashboard_components.EditImageInput(fmt.Sprintf("/api/v1/admin/quiz/edit-image?quiz-id=%s", quiz.ID), fmt.Sprintf("/api/v1/admin/quiz/upload-image?quiz-id=%s", quiz.ID),
-					&quiz.ImageURL, true, "")
+					&quiz.ImageURL, true, "", dashboard_components.IdPrefixQuiz)
 			</form>
 			// Quiz Articles
 			@dashboard_components.EditQuizForm() {


### PR DESCRIPTION
the image file upload inputs look *better*... than the default html one. Added bigger drop zone for the image files, maybe it should be even bigger (?)
also fix duplicate element ids (added a prefix parameter) in quiz edit and question edit (they reuse the image upload component)
and fix bug where image file upload would not work on question creation